### PR TITLE
fix: upgrade pytest 8.3.5 to 9.0.3 (tmpdir vulnerability)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 ruff==0.11.12
-pytest==8.3.5
+pytest==9.0.3
 pytest-mock==3.14.0


### PR DESCRIPTION
Dependabot alert #1 — pytest has vulnerable tmpdir handling. Fixed in 9.0.3.

Generated with [Claude Code](https://claude.com/claude-code)