### PR TITLE
fix: bump pytest to 9.0.3 (CVE-2025-71176), drop EOL Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.13"]
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 ruff==0.11.12
-pytest==8.3.5
+pytest==9.0.3
 pytest-mock==3.15.1


### PR DESCRIPTION
## Summary
- Bumps pytest from 8.3.5 to 9.0.3 to fix CVE-2025-71176 (vulnerable tmpdir handling)
- Drops Python 3.9 from CI matrix (EOL since Oct 2025)

## Test plan
- [ ] CI passes on Python 3.11 and 3.13
- [ ] Dependabot alert #1 resolves after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)