### PR TITLE
chore: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Something doesn't work the way it should
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. If the issue is a CVE check that flagged a package incorrectly, please use the **False positive** template instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I run `brew safe-upgrade`, it...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `brew safe-upgrade ...`
+        2. See output
+    validations:
+      required: true
+  - type: input
+    id: install-source
+    attributes:
+      label: How did you install the tool?
+      placeholder: e.g. install.sh on 2026-04-20, or git clone of commit abc123
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS Apple Silicon
+        - macOS Intel
+        - Linux
+    validations:
+      required: true
+  - type: input
+    id: brew-version
+    attributes:
+      label: Homebrew version
+      description: Output of `brew --version`
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python3 --version`
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output / logs
+      description: Paste the full command output. Use code blocks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/sharkyger/homebrew-safe-upgrade/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories. Do not open a public issue.
+  - name: Question or discussion
+    url: https://github.com/sharkyger/homebrew-safe-upgrade/discussions
+    about: For questions, ideas, or general discussion, open a Discussion instead of an Issue.

--- a/.github/ISSUE_TEMPLATE/false_positive.yml
+++ b/.github/ISSUE_TEMPLATE/false_positive.yml
@@ -1,0 +1,59 @@
+name: False positive (CVE check)
+description: A package was flagged but the version isn't actually affected
+labels: [false-positive, cve-check]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        False positives usually come from CVE descriptions that don't include precise CPE version data — the tool falls back to keyword/version-string matching, which can misfire.
+
+        Please include enough detail that the fix can be tested.
+  - type: input
+    id: package
+    attributes:
+      label: Package name
+      placeholder: e.g. imagemagick
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version that was flagged
+      placeholder: e.g. 7.1.2-21
+    validations:
+      required: true
+  - type: input
+    id: cve
+    attributes:
+      label: CVE ID(s) flagged
+      description: Comma-separated if multiple
+      placeholder: e.g. CVE-2026-12345
+    validations:
+      required: true
+  - type: dropdown
+    id: source
+    attributes:
+      label: Which database flagged it?
+      multiple: true
+      options:
+        - NIST NVD
+        - OSV.dev
+        - GitHub Advisory
+        - Not sure / multiple
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Why this is a false positive
+      description: Link the CVE entry, paste the affected-version range, or explain why your version isn't in scope.
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Tool output
+      description: Paste the full output of the security check.
+      render: shell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Suggest a new flag, behavior, or capability
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For larger ideas, consider opening a [Discussion](https://github.com/sharkyger/homebrew-safe-upgrade/discussions) first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point. Concrete examples help.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like the tool to behave? Sketch the CLI surface if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why they don't fit.
+  - type: checkboxes
+    id: contributions
+    attributes:
+      label: Are you willing to help?
+      options:
+        - label: I'd like to submit a PR for this
+        - label: I can help test

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## What changed
+
+<!-- One or two sentences. What does this PR actually do? -->
+
+## Why
+
+<!-- The problem this solves. Link an issue if there is one. -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (existing CLI or behavior changes)
+- [ ] Documentation only
+- [ ] CI / tooling / chore
+
+## Checklist
+
+- [ ] Tests pass locally (`pytest`)
+- [ ] Linters pass (`ruff check .`, `shellcheck` on changed shell files)
+- [ ] If behavior changed, tests were added or updated
+- [ ] If a new flag was added, it's documented in the README
+- [ ] No new dependencies (or: new dependencies are justified in the description)
+- [ ] Security-relevant changes are flagged in the description
+
+## Notes for reviewer
+
+<!-- Anything else worth knowing — design decisions, things you're unsure about, follow-ups. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,16 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct.
+
+In short: be respectful, assume good faith, focus on the technical problem.
+
+## Reporting
+
+If you experience or witness behavior that violates the Contributor Covenant, report it through GitHub:
+
+- For content (issues, PRs, comments): <https://github.com/contact/report-content>
+- For users: <https://github.com/contact/report-abuse>
+
+GitHub's Trust & Safety team handles reports independently. As a solo maintainer I don't run a separate inbox for this — using GitHub's flow keeps the process traceable and consistent across projects.
+
+For security vulnerabilities (a separate concern), see [SECURITY.md](SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+Thanks for considering a contribution to homebrew-safe-upgrade. This is a solo-maintained tool, so a few notes up front to set expectations:
+
+- I review PRs and issues when I have time, usually within a few days.
+- Small, focused changes get merged faster than sprawling ones.
+- If you're planning something bigger than a bug fix, open a [Discussion](https://github.com/sharkyger/homebrew-safe-upgrade/discussions) or issue first so we can align before you write code.
+
+## Reporting issues
+
+Three flavors:
+
+- **Bug** — something doesn't work the way it should
+- **Feature request** — something you'd like the tool to do
+- **False positive** — the tool flagged a package that shouldn't be flagged (the most common kind — pick this one if a CVE check looks wrong)
+
+Pick the right template at <https://github.com/sharkyger/homebrew-safe-upgrade/issues/new/choose>.
+
+**Security issues**: do not open a public issue. See [SECURITY.md](SECURITY.md) for the private disclosure flow.
+
+## Dev setup
+
+```bash
+git clone https://github.com/sharkyger/homebrew-safe-upgrade.git
+cd homebrew-safe-upgrade
+pip install -r requirements-dev.txt
+```
+
+Run the tests:
+
+```bash
+pytest
+```
+
+Run the linters (CI will block your PR if these fail):
+
+```bash
+ruff check .
+shellcheck brew-safe-upgrade brew-safe-install brew-safe-update install.sh
+```
+
+## Branching
+
+- Branch from `main`
+- Use prefixes: `feature/`, `fix/`, `docs/`, `chore/`
+- One logical change per branch — don't mix unrelated work
+
+## Pull requests
+
+Good PRs:
+
+- Solve one problem (or a tightly scoped set of related ones)
+- Include or update tests when behavior changes
+- Pass CI: ruff, shellcheck, pytest, CodeQL, Gitleaks
+- Have a description that says **what** changed and **why** — not just what
+
+Less good PRs:
+
+- Mix unrelated changes
+- Add new dependencies without justification (this tool intentionally uses Python stdlib only)
+- Skip tests "because it's a small change"
+- Reformat unrelated files
+
+## Adding new ecosystems to the standalone checker
+
+`dependency_security_check.py` works for any ecosystem the three databases cover. Adding a new one usually means:
+
+1. Add the ecosystem to the `OSV_ECOSYSTEMS` map
+2. Add version-resolution logic if the ecosystem has a "latest" registry
+3. Add tests covering at least one known-vulnerable and one known-clean version
+
+## Maintainer
+
+Maintained by [@sharkyger](https://github.com/sharkyger). Thanks for contributing.


### PR DESCRIPTION
## Summary

Fills the gaps in the GitHub community profile (was 57%, gets to 100%):

- **CODE_OF_CONDUCT.md** — adopts Contributor Covenant 2.1 by reference; enforcement points to GitHub's report-content / report-abuse flows instead of a separate inbox.
- **CONTRIBUTING.md** — dev setup, branch naming, what makes a good PR, pointer to the false-positive template (the most common report kind for this tool).
- **.github/ISSUE_TEMPLATE/** — three YAML form templates (bug, feature request, false positive) plus `config.yml` that disables blank issues and routes security reports to GitHub Security Advisories.
- **.github/PULL_REQUEST_TEMPLATE.md** — checklist covering tests, linters, docs, and the no-new-deps rule.

No code or behavior changes. Two new repo labels (`false-positive`, `cve-check`) were created to back the false-positive issue template.

## Test plan

- [ ] All four `.yml` files render correctly in the GitHub issue picker
- [ ] `false_positive.yml` multi-select dropdown works (verified `multiple: true` against GitHub's form schema docs)
- [ ] Security advisory link in `config.yml` resolves
- [ ] Community profile health goes from 57% to 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)