### PR TITLE
fix(deps): hardening pass after v0.1.0 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ The project is pre-1.0; expect minor breaking changes between 0.x releases until
 
 ## [Unreleased]
 
+## [0.1.1] — 2026-04-26
+
+Hardening pass following the v0.1.0 review. All changes are internal correctness and defense-in-depth improvements; the public flag/env-var surface is unchanged.
+
+### Fixed
+- `brew list --versions` parsing now uses `awk '$NF'` instead of `awk '$2'`, so when multiple kegs of one formula are installed the **latest** version is used for the incoming-vs-installed comparison rather than the oldest.
+- `INCOMING_DEPS` is now a proper bash array. Iteration uses quoted `${INCOMING_DEPS_ARR[@]}` expansion, preserving whitespace in pathological tap dep names that the previous flat-string approach would have split.
+- `--min-age` for tap-namespaced deps (`foo/bar/baz`) is now an explicit `[skip-dep-age]` log line. Previously the GitHub `homebrew-core` lookup would 404 silently and the age gate fell through unenforced.
+
+### Security (defense in depth)
+- Dep names from `brew deps` output are validated against a `^[a-zA-Z0-9@._/-]+$` regex before being interpolated into any curl URL or passed to the CVE checker. A malformed name from a compromised tap is rejected with `[skip-dep] -- invalid name, refusing to query`.
+- The same regex guard is now applied to the **main-package** age check in both `brew-safe-install` and `brew-safe-upgrade`. (Previously only the dep-check code was protected; the main-package path inherited a pre-existing gap from before the SSRF input validation in PR #11.)
+
+### Changed
+- The pre-install / pre-upgrade warning block no longer combines vulnerable and too-fresh deps under one `"known issues"` header. Vulnerable deps now appear under `"WARNING: incoming dependencies have known CVEs:"`; fresh deps under `"Incoming dependencies are below --min-age:"`. They are distinct risk signals and the previous wording conflated them.
+- `brew-safe-upgrade --yes` stderr bypass message reworded from `"despite dep CVE warnings"` to `"despite dep warnings"` (now covers both CVE and freshness holds).
+
+### Documented
+- Added an in-code design note explaining why transitive deps deliberately do **not** receive the CVE-aware `--min-age` bypass that applies to the user-named package.
+
+
+
 ### Added
 - Transitive dependency check for `brew safe-install` and `brew safe-upgrade`. The same vulnerability gate that protects the package you're installing is now applied to the dependencies that come in with it — both brand-new deps and existing deps whose version is being bumped. Already-installed deps that aren't changing are deliberately left to [`brew-vulns`](https://github.com/Homebrew/homebrew-brew-vulns).
 - For `safe-upgrade`, incoming deps are deduplicated across the whole upgrade batch (so `openssl@3` appearing in five outdated packages is checked once).

--- a/brew-safe-install
+++ b/brew-safe-install
@@ -128,7 +128,9 @@ except Exception:
     fi
 
     # --- Min-age check (opt-in) ---
-    if [ "$MIN_AGE" -gt 0 ] 2>/dev/null && [ "$PKG_TYPE" = "formula" ]; then
+    # Defense in depth: only allow Homebrew-shaped names through the URL we
+    # construct from `brew info` output.
+    if [ "$MIN_AGE" -gt 0 ] 2>/dev/null && [ "$PKG_TYPE" = "formula" ] && [[ "$BARE_NAME" =~ ^[a-zA-Z0-9@._/-]+$ ]]; then
         FIRST_LETTER=$(echo "$BARE_NAME" | cut -c1)
         COMMIT_JSON=$(curl -sf "https://api.github.com/repos/Homebrew/homebrew-core/commits?path=Formula/${FIRST_LETTER}/${BARE_NAME}.rb&per_page=1" 2>/dev/null || echo "[]")
         AGE_INFO=$(echo "$COMMIT_JSON" | python3 -c "
@@ -231,29 +233,52 @@ fi
 CLEAN_PKGS=$(echo "$CLEAN_PKGS" | xargs)  # trim
 
 # --- Transitive dependency check (default on; --no-deps to skip) ---
-# Entry format inside INCOMING_DEPS: "<dep>|<version>"
-# `|` is used as the separator because Homebrew formula names contain `@`
-# (e.g. openssl@3) and versions occasionally contain `@` too. `|` cannot.
-DEP_BLOCKED=""
-DEP_BLOCKED_REASONS=""
+#
+# Design note: the CVE-aware bypass that skips --min-age for the user-named
+# package when the installed version has known CVEs is intentionally NOT
+# applied to transitive deps. Reasons: (1) the user explicitly opted into
+# the named package, deps came along; (2) deps follow stricter rules so a
+# fresh unverified dep can't ride in under cover of "the parent has CVEs";
+# (3) running an installed-version CVE query for every dep would double
+# rate-limited NVD traffic with little practical benefit. Held deps are
+# surfaced via [HOLD-DEP]; user can override at the prompt.
+#
+# Storage: INCOMING_DEPS_ARR holds "<dep>|<version>" entries. `|` chosen
+# because Homebrew formula names contain `@` (e.g. openssl@3) and versions
+# occasionally do too — `|` cannot appear in either.
+DEP_BLOCKED_VULN=""
+DEP_BLOCKED_VULN_REASONS=""
+DEP_BLOCKED_HOLD=""
+DEP_BLOCKED_HOLD_REASONS=""
 DEP_SKIPPED=""
+
+# Defense in depth: only allow Homebrew-shaped names through any URL or
+# subprocess argument we construct from `brew deps` output.
+DEP_NAME_RE='^[a-zA-Z0-9@._/-]+$'
 
 if [ "$CHECK_DEPS" = true ] && [ -n "$CLEAN_PKGS" ]; then
     echo ""
     echo "Checking transitive dependencies..."
 
-    INCOMING_DEPS=""
+    INCOMING_DEPS_ARR=()
     for pkg in $CLEAN_PKGS; do
         # Read deps into an array preserving lines so a dep name with a space
         # (third-party taps) isn't word-split. macOS ships bash 3.2, so no
         # `mapfile` — explicit `while read` instead.
-        DEPS_ARR=()
+        DEPS_PARSED_ARR=()
         while IFS= read -r line; do
-            [ -n "$line" ] && DEPS_ARR+=("$line")
+            [ -n "$line" ] && DEPS_PARSED_ARR+=("$line")
         done < <(brew deps "$pkg" 2>/dev/null || true)
 
-        for dep in ${DEPS_ARR[@]+"${DEPS_ARR[@]}"}; do
+        for dep in ${DEPS_PARSED_ARR[@]+"${DEPS_PARSED_ARR[@]}"}; do
             [ -z "$dep" ] && continue
+
+            # Reject malformed names from compromised taps before any URL or
+            # subprocess argument is constructed.
+            if [[ ! "$dep" =~ $DEP_NAME_RE ]]; then
+                echo "    [skip-dep] $dep -- invalid name, refusing to query"
+                continue
+            fi
 
             LATEST=$(brew info --json=v2 --formula "$dep" 2>/dev/null | python3 -c "
 import sys, json
@@ -265,37 +290,48 @@ try:
 except Exception:
     pass
 " 2>/dev/null)
-            # Strip Homebrew revision suffix (`_1`, `_2`, …) so a revision bump
-            # of an already-current formula isn't classified as incoming.
-            INSTALLED_VER=$(brew list --versions --formula "$dep" 2>/dev/null | awk '{print $2}' | sed 's/_[0-9]*$//')
+            # awk '$NF' grabs the LAST version when multiple kegs are installed.
+            # sed strips Homebrew revision suffix (`_1`, `_2`, …) so a revision
+            # bump of an already-current formula isn't classified as incoming.
+            INSTALLED_VER=$(brew list --versions --formula "$dep" 2>/dev/null | awk '{print $NF}' | sed 's/_[0-9]*$//')
 
             [ -z "$LATEST" ] && continue
 
             if [ -z "$INSTALLED_VER" ] || [ "$INSTALLED_VER" != "$LATEST" ]; then
-                if ! echo " $INCOMING_DEPS " | grep -qF " ${dep}|${LATEST} "; then
-                    INCOMING_DEPS="$INCOMING_DEPS ${dep}|${LATEST}"
-                fi
+                # Array-based dedup — quoted iteration preserves whitespace
+                # in pathological dep names (taps); flat-string dedup did not.
+                _entry="${dep}|${LATEST}"
+                _seen=0
+                for _e in ${INCOMING_DEPS_ARR[@]+"${INCOMING_DEPS_ARR[@]}"}; do
+                    [ "$_e" = "$_entry" ] && _seen=1 && break
+                done
+                [ "$_seen" -eq 0 ] && INCOMING_DEPS_ARR+=("$_entry")
             fi
         done
     done
 
-    INCOMING_DEPS=$(echo "$INCOMING_DEPS" | xargs)
+    DEP_COUNT=${#INCOMING_DEPS_ARR[@]}
 
-    if [ -z "$INCOMING_DEPS" ]; then
+    if [ "$DEP_COUNT" -eq 0 ]; then
         echo "  No new dependency versions coming in."
     else
-        DEP_COUNT=$(echo "$INCOMING_DEPS" | wc -w | tr -d ' ')
         echo "  Found $DEP_COUNT incoming dependency version(s) to check"
         echo ""
 
-        for entry in $INCOMING_DEPS; do
+        for entry in ${INCOMING_DEPS_ARR[@]+"${INCOMING_DEPS_ARR[@]}"}; do
             DEP=${entry%|*}
             DEP_VER=${entry##*|}
 
             if [ "$MIN_AGE" -gt 0 ] 2>/dev/null; then
-                FIRST_LETTER=$(echo "$DEP" | cut -c1)
-                COMMIT_JSON=$(curl -sf "https://api.github.com/repos/Homebrew/homebrew-core/commits?path=Formula/${FIRST_LETTER}/${DEP}.rb&per_page=1" 2>/dev/null || echo "[]")
-                AGE_INFO=$(echo "$COMMIT_JSON" | python3 -c "
+                # Tap-namespaced deps (foo/bar/baz) don't live in homebrew-core,
+                # so the GitHub commits API cannot tell us their age. Skip the
+                # age gate explicitly rather than falling through silently.
+                if [[ "$DEP" == */* ]]; then
+                    echo "    [skip-dep-age] $DEP — tap formula, age unavailable from homebrew-core"
+                else
+                    FIRST_LETTER=$(echo "$DEP" | cut -c1)
+                    COMMIT_JSON=$(curl -sf "https://api.github.com/repos/Homebrew/homebrew-core/commits?path=Formula/${FIRST_LETTER}/${DEP}.rb&per_page=1" 2>/dev/null || echo "[]")
+                    AGE_INFO=$(echo "$COMMIT_JSON" | python3 -c "
 import sys, json, datetime
 try:
     data = json.load(sys.stdin)
@@ -308,13 +344,14 @@ try:
 except Exception:
     print('-1 unknown')
 " 2>/dev/null)
-                AGE_DAYS=$(echo "$AGE_INFO" | awk '{print $1}')
-                PUB_DATE=$(echo "$AGE_INFO" | awk '{print $2}')
-                if [ "$AGE_DAYS" -ge 0 ] 2>/dev/null && [ "$AGE_DAYS" -lt "$MIN_AGE" ]; then
-                    echo "    [HOLD-DEP] $DEP $DEP_VER -- released $AGE_DAYS day(s) ago ($PUB_DATE), min-age: $MIN_AGE days"
-                    DEP_BLOCKED="$DEP_BLOCKED $DEP"
-                    DEP_BLOCKED_REASONS="${DEP_BLOCKED_REASONS}    $DEP $DEP_VER: too fresh ($AGE_DAYS days old, min-age $MIN_AGE)"$'\n'
-                    continue
+                    AGE_DAYS=$(echo "$AGE_INFO" | awk '{print $1}')
+                    PUB_DATE=$(echo "$AGE_INFO" | awk '{print $2}')
+                    if [ "$AGE_DAYS" -ge 0 ] 2>/dev/null && [ "$AGE_DAYS" -lt "$MIN_AGE" ]; then
+                        echo "    [HOLD-DEP] $DEP $DEP_VER -- released $AGE_DAYS day(s) ago ($PUB_DATE), min-age: $MIN_AGE days"
+                        DEP_BLOCKED_HOLD="$DEP_BLOCKED_HOLD $DEP"
+                        DEP_BLOCKED_HOLD_REASONS="${DEP_BLOCKED_HOLD_REASONS}    $DEP $DEP_VER: too fresh ($AGE_DAYS days old, min-age $MIN_AGE)"$'\n'
+                        continue
+                    fi
                 fi
             fi
 
@@ -325,8 +362,8 @@ except Exception:
             elif [ "$DEP_EXIT" -eq 1 ]; then
                 echo "    [VULN-DEP] $DEP $DEP_VER -- vulnerabilities found"
                 SUMMARY=$(echo "$DEP_RESULT" | grep -E 'CRITICAL|HIGH|MEDIUM' | head -1 || true)
-                DEP_BLOCKED="$DEP_BLOCKED $DEP"
-                DEP_BLOCKED_REASONS="${DEP_BLOCKED_REASONS}    $DEP $DEP_VER: ${SUMMARY:-vulnerabilities reported}"$'\n'
+                DEP_BLOCKED_VULN="$DEP_BLOCKED_VULN $DEP"
+                DEP_BLOCKED_VULN_REASONS="${DEP_BLOCKED_VULN_REASONS}    $DEP $DEP_VER: ${SUMMARY:-vulnerabilities reported}"$'\n'
             else
                 echo "    [skip-dep] $DEP $DEP_VER -- check failed (network or DB error)"
                 DEP_SKIPPED="$DEP_SKIPPED $DEP"
@@ -339,10 +376,18 @@ except Exception:
             echo "  These will install unchecked. Re-run later or use --no-deps to suppress."
         fi
 
-        if [ -n "$DEP_BLOCKED" ]; then
+        # Distinct sections for vulnerable vs. too-fresh: they are different
+        # risk signals and the previous combined header conflated them.
+        if [ -n "$DEP_BLOCKED_VULN" ] || [ -n "$DEP_BLOCKED_HOLD" ]; then
             echo ""
-            echo "WARNING: incoming dependencies have known issues:"
-            printf "%s" "$DEP_BLOCKED_REASONS"
+            if [ -n "$DEP_BLOCKED_VULN" ]; then
+                echo "WARNING: incoming dependencies have known CVEs:"
+                printf "%s" "$DEP_BLOCKED_VULN_REASONS"
+            fi
+            if [ -n "$DEP_BLOCKED_HOLD" ]; then
+                echo "Incoming dependencies are below --min-age:"
+                printf "%s" "$DEP_BLOCKED_HOLD_REASONS"
+            fi
             echo "Proceeding will let brew install them anyway."
             read -rp "Continue install of $CLEAN_PKGS? [y/N] " DEP_CONFIRM
             if [[ ! "$DEP_CONFIRM" =~ ^[yY] ]]; then

--- a/brew-safe-upgrade
+++ b/brew-safe-upgrade
@@ -118,7 +118,14 @@ if [ "$MIN_AGE" -gt 0 ] 2>/dev/null; then
 
     FILTERED_OUTDATED=""
     while read -r name installed current; do
-        # Query GitHub API for the formula's last commit date
+        # Defense in depth: only allow Homebrew-shaped names through the URL.
+        if [[ ! "$name" =~ ^[a-zA-Z0-9@._/-]+$ ]]; then
+            echo "  [skip] $name -- invalid name, refusing to query"
+            FILTERED_OUTDATED="${FILTERED_OUTDATED}${name} ${installed} ${current}"$'\n'
+            continue
+        fi
+
+        # Query GitHub API for the formula's last commit date.
         # Uses the first letter subdirectory convention: Formula/g/gitleaks.rb
         FIRST_LETTER=$(echo "$name" | cut -c1)
         COMMIT_JSON=$(curl -sf "https://api.github.com/repos/Homebrew/homebrew-core/commits?path=Formula/${FIRST_LETTER}/${name}.rb&per_page=1" 2>/dev/null || echo "[]")
@@ -293,29 +300,47 @@ if [ -n "$SKIPPED_PKGS" ]; then
 fi
 
 # --- Transitive dependency check (default on; --no-deps to skip) ---
-# Entry format inside INCOMING_DEPS: "<dep>|<version>"
-# `|` is used as the separator because Homebrew formula names contain `@`
-# (e.g. openssl@3) and versions occasionally contain `@` too. `|` cannot.
-DEP_BLOCKED=""
-DEP_BLOCKED_REASONS=""
+#
+# Design note: the CVE-aware bypass that skips --min-age for the user-named
+# package when the installed version has known CVEs is intentionally NOT
+# applied to transitive deps. Reasons: (1) the user explicitly opted into
+# the named package, deps came along; (2) deps follow stricter rules so a
+# fresh unverified dep can't ride in under cover of "the parent has CVEs";
+# (3) running an installed-version CVE query for every dep would double
+# rate-limited NVD traffic with little practical benefit. Held deps are
+# surfaced via [HOLD-DEP]; user can override at the prompt.
+#
+# Storage: INCOMING_DEPS_ARR holds "<dep>|<version>" entries. `|` chosen
+# because Homebrew formula names contain `@` (e.g. openssl@3) and versions
+# occasionally do too — `|` cannot appear in either.
+DEP_BLOCKED_VULN=""
+DEP_BLOCKED_VULN_REASONS=""
+DEP_BLOCKED_HOLD=""
+DEP_BLOCKED_HOLD_REASONS=""
 DEP_SKIPPED=""
+
+# Defense in depth: only allow Homebrew-shaped names through any URL or
+# subprocess argument we construct from `brew deps` output.
+DEP_NAME_RE='^[a-zA-Z0-9@._/-]+$'
 
 if [ "$CHECK_DEPS" = true ] && [ -n "$CLEAN_PKGS" ]; then
     echo ""
     echo "Checking transitive dependencies (deduped across batch)..."
 
-    INCOMING_DEPS=""
+    INCOMING_DEPS_ARR=()
     for pkg in $CLEAN_PKGS; do
-        # Read deps into an array preserving lines so a dep name with a space
-        # (third-party taps) isn't word-split. macOS ships bash 3.2, so no
-        # `mapfile` — explicit `while read` instead.
-        DEPS_ARR=()
+        DEPS_PARSED_ARR=()
         while IFS= read -r line; do
-            [ -n "$line" ] && DEPS_ARR+=("$line")
+            [ -n "$line" ] && DEPS_PARSED_ARR+=("$line")
         done < <(brew deps "$pkg" 2>/dev/null || true)
 
-        for dep in ${DEPS_ARR[@]+"${DEPS_ARR[@]}"}; do
+        for dep in ${DEPS_PARSED_ARR[@]+"${DEPS_PARSED_ARR[@]}"}; do
             [ -z "$dep" ] && continue
+
+            if [[ ! "$dep" =~ $DEP_NAME_RE ]]; then
+                echo "    [skip-dep] $dep -- invalid name, refusing to query"
+                continue
+            fi
 
             LATEST=$(brew info --json=v2 --formula "$dep" 2>/dev/null | python3 -c "
 import sys, json
@@ -327,9 +352,10 @@ try:
 except Exception:
     pass
 " 2>/dev/null)
-            # Strip Homebrew revision suffix (`_1`, `_2`, …) so a revision bump
-            # of an already-current formula isn't classified as incoming.
-            INSTALLED_VER=$(brew list --versions --formula "$dep" 2>/dev/null | awk '{print $2}' | sed 's/_[0-9]*$//')
+            # awk '$NF' grabs the LAST version when multiple kegs are installed.
+            # sed strips Homebrew revision suffix (`_1`, `_2`, …) so a revision
+            # bump of an already-current formula isn't classified as incoming.
+            INSTALLED_VER=$(brew list --versions --formula "$dep" 2>/dev/null | awk '{print $NF}' | sed 's/_[0-9]*$//')
 
             [ -z "$LATEST" ] && continue
 
@@ -339,30 +365,40 @@ except Exception:
             fi
 
             if [ -z "$INSTALLED_VER" ] || [ "$INSTALLED_VER" != "$LATEST" ]; then
-                if ! echo " $INCOMING_DEPS " | grep -qF " ${dep}|${LATEST} "; then
-                    INCOMING_DEPS="$INCOMING_DEPS ${dep}|${LATEST}"
-                fi
+                # Array-based dedup — quoted iteration preserves whitespace
+                # in pathological dep names (taps); flat-string dedup did not.
+                _entry="${dep}|${LATEST}"
+                _seen=0
+                for _e in ${INCOMING_DEPS_ARR[@]+"${INCOMING_DEPS_ARR[@]}"}; do
+                    [ "$_e" = "$_entry" ] && _seen=1 && break
+                done
+                [ "$_seen" -eq 0 ] && INCOMING_DEPS_ARR+=("$_entry")
             fi
         done
     done
 
-    INCOMING_DEPS=$(echo "$INCOMING_DEPS" | xargs)
+    DEP_COUNT=${#INCOMING_DEPS_ARR[@]}
 
-    if [ -z "$INCOMING_DEPS" ]; then
+    if [ "$DEP_COUNT" -eq 0 ]; then
         echo "  No new dependency versions coming in."
     else
-        DEP_COUNT=$(echo "$INCOMING_DEPS" | wc -w | tr -d ' ')
         echo "  Found $DEP_COUNT incoming dependency version(s) to check"
         echo ""
 
-        for entry in $INCOMING_DEPS; do
+        for entry in ${INCOMING_DEPS_ARR[@]+"${INCOMING_DEPS_ARR[@]}"}; do
             DEP=${entry%|*}
             DEP_VER=${entry##*|}
 
             if [ "$MIN_AGE" -gt 0 ] 2>/dev/null; then
-                FIRST_LETTER=$(echo "$DEP" | cut -c1)
-                COMMIT_JSON=$(curl -sf "https://api.github.com/repos/Homebrew/homebrew-core/commits?path=Formula/${FIRST_LETTER}/${DEP}.rb&per_page=1" 2>/dev/null || echo "[]")
-                AGE_INFO=$(echo "$COMMIT_JSON" | python3 -c "
+                # Tap-namespaced deps (foo/bar/baz) don't live in homebrew-core,
+                # so the GitHub commits API cannot tell us their age. Skip the
+                # age gate explicitly rather than falling through silently.
+                if [[ "$DEP" == */* ]]; then
+                    echo "    [skip-dep-age] $DEP — tap formula, age unavailable from homebrew-core"
+                else
+                    FIRST_LETTER=$(echo "$DEP" | cut -c1)
+                    COMMIT_JSON=$(curl -sf "https://api.github.com/repos/Homebrew/homebrew-core/commits?path=Formula/${FIRST_LETTER}/${DEP}.rb&per_page=1" 2>/dev/null || echo "[]")
+                    AGE_INFO=$(echo "$COMMIT_JSON" | python3 -c "
 import sys, json, datetime
 try:
     data = json.load(sys.stdin)
@@ -375,13 +411,14 @@ try:
 except Exception:
     print('-1 unknown')
 " 2>/dev/null)
-                AGE_DAYS=$(echo "$AGE_INFO" | awk '{print $1}')
-                PUB_DATE=$(echo "$AGE_INFO" | awk '{print $2}')
-                if [ "$AGE_DAYS" -ge 0 ] 2>/dev/null && [ "$AGE_DAYS" -lt "$MIN_AGE" ]; then
-                    echo "    [HOLD-DEP] $DEP $DEP_VER -- released $AGE_DAYS day(s) ago ($PUB_DATE), min-age: $MIN_AGE days"
-                    DEP_BLOCKED="$DEP_BLOCKED $DEP"
-                    DEP_BLOCKED_REASONS="${DEP_BLOCKED_REASONS}    $DEP $DEP_VER: too fresh ($AGE_DAYS days old, min-age $MIN_AGE)"$'\n'
-                    continue
+                    AGE_DAYS=$(echo "$AGE_INFO" | awk '{print $1}')
+                    PUB_DATE=$(echo "$AGE_INFO" | awk '{print $2}')
+                    if [ "$AGE_DAYS" -ge 0 ] 2>/dev/null && [ "$AGE_DAYS" -lt "$MIN_AGE" ]; then
+                        echo "    [HOLD-DEP] $DEP $DEP_VER -- released $AGE_DAYS day(s) ago ($PUB_DATE), min-age: $MIN_AGE days"
+                        DEP_BLOCKED_HOLD="$DEP_BLOCKED_HOLD $DEP"
+                        DEP_BLOCKED_HOLD_REASONS="${DEP_BLOCKED_HOLD_REASONS}    $DEP $DEP_VER: too fresh ($AGE_DAYS days old, min-age $MIN_AGE)"$'\n'
+                        continue
+                    fi
                 fi
             fi
 
@@ -392,8 +429,8 @@ except Exception:
             elif [ "$DEP_EXIT" -eq 1 ]; then
                 echo "    [VULN-DEP] $DEP $DEP_VER -- vulnerabilities found"
                 SUMMARY=$(echo "$DEP_RESULT" | grep -E 'CRITICAL|HIGH|MEDIUM' | head -1 || true)
-                DEP_BLOCKED="$DEP_BLOCKED $DEP"
-                DEP_BLOCKED_REASONS="${DEP_BLOCKED_REASONS}    $DEP $DEP_VER: ${SUMMARY:-vulnerabilities reported}"$'\n'
+                DEP_BLOCKED_VULN="$DEP_BLOCKED_VULN $DEP"
+                DEP_BLOCKED_VULN_REASONS="${DEP_BLOCKED_VULN_REASONS}    $DEP $DEP_VER: ${SUMMARY:-vulnerabilities reported}"$'\n'
             else
                 echo "    [skip-dep] $DEP $DEP_VER -- check failed (network or DB error)"
                 DEP_SKIPPED="$DEP_SKIPPED $DEP"
@@ -406,14 +443,22 @@ except Exception:
             echo "  These will upgrade unchecked. Re-run later or use --no-deps to suppress."
         fi
 
-        if [ -n "$DEP_BLOCKED" ]; then
+        # Distinct sections for vulnerable vs. too-fresh: they are different
+        # risk signals and the previous combined header conflated them.
+        if [ -n "$DEP_BLOCKED_VULN" ] || [ -n "$DEP_BLOCKED_HOLD" ]; then
             echo ""
-            echo "WARNING: incoming dependencies have known issues:"
-            printf "%s" "$DEP_BLOCKED_REASONS"
+            if [ -n "$DEP_BLOCKED_VULN" ]; then
+                echo "WARNING: incoming dependencies have known CVEs:"
+                printf "%s" "$DEP_BLOCKED_VULN_REASONS"
+            fi
+            if [ -n "$DEP_BLOCKED_HOLD" ]; then
+                echo "Incoming dependencies are below --min-age:"
+                printf "%s" "$DEP_BLOCKED_HOLD_REASONS"
+            fi
             echo "Proceeding will let brew upgrade them anyway."
             if [ "$AUTO_YES" = true ]; then
                 # Visible on stderr so it lands in CI logs even when stdout is redirected
-                echo "[--yes] continuing despite dep CVE warnings — review the lines above" >&2
+                echo "[--yes] continuing despite dep warnings — review the lines above" >&2
             else
                 read -rp "Continue upgrade? [y/N] " DEP_CONFIRM
                 if [[ ! "$DEP_CONFIRM" =~ ^[yY] ]]; then

--- a/tests/test_brew_safe_deps.py
+++ b/tests/test_brew_safe_deps.py
@@ -48,16 +48,22 @@ def write_formula_info(fixture_dir: Path, name: str, stable: str, installed=Fals
         ],
         "casks": [],
     }
-    (fixture_dir / f"info_{name}.json").write_text(json.dumps(payload))
+    target = fixture_dir / f"info_{name}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload))
 
 
 def write_deps(fixture_dir: Path, name: str, deps: list[str]):
-    (fixture_dir / f"deps_{name}.txt").write_text("\n".join(deps) + "\n" if deps else "")
+    target = fixture_dir / f"deps_{name}.txt"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("\n".join(deps) + "\n" if deps else "")
 
 
 def write_installed_version(fixture_dir: Path, name: str, version: str):
     """Mimic `brew list --versions --formula <name>` → '<name> <version>'."""
-    (fixture_dir / f"list_{name}.txt").write_text(f"{name} {version}\n")
+    target = fixture_dir / f"list_{name}.txt"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(f"{name} {version}\n")
 
 
 def run_safe_install(
@@ -233,7 +239,7 @@ def test_vulnerable_dep_triggers_warning_and_cancellation(mock_env, tmp_path):
         input_text="n\n",
     )
     assert "[VULN-DEP] libfoo 1.2.3" in result.stdout
-    assert "WARNING: incoming dependencies have known issues" in result.stdout
+    assert "WARNING: incoming dependencies have known CVEs" in result.stdout
     assert "Cancelled." in result.stdout
     assert result.returncode == 0  # current contract; cancel = clean exit
 
@@ -258,6 +264,105 @@ def test_dep_check_failure_is_surfaced_in_summary(mock_env, tmp_path):
     assert "[skip-dep] libfoo 1.2.3" in result.stdout
     assert "dep checks failed for:" in result.stdout
     assert "libfoo" in result.stdout
+
+
+# ----------------------- hardening (#19, #20, #22, #23, #24) -----------------------
+
+
+def test_multi_keg_installed_uses_latest_version_for_compare(mock_env, tmp_path):
+    """
+    `brew list --versions` returns multiple kegs space-separated on one line.
+    The classifier must compare against the LAST (newest) version, not the first,
+    otherwise an already-current dep is misclassified as incoming. (#19)
+    """
+    write_formula_info(mock_env, "wget", "1.25.0")
+    write_formula_info(mock_env, "openssl@3", "3.5.0")
+    write_deps(mock_env, "wget", ["openssl@3"])
+    # Two kegs installed: an old one and the current one.
+    (mock_env / "list_openssl@3.txt").write_text("openssl@3 3.0.0 3.5.0\n")
+
+    stub = make_cve_stub(tmp_path)
+
+    result = run_safe_install(
+        ["wget"],
+        env_extra={"DEPENDENCY_SECURITY_CHECK": str(stub)},
+        input_text="n\n",
+    )
+    # Latest is already installed → not incoming
+    assert "No new dependency versions coming in." in result.stdout
+
+
+def test_invalid_dep_name_is_rejected_before_query(mock_env, tmp_path):
+    """
+    A dep name that fails the regex guard must be skipped with [skip-dep] —
+    no curl URL constructed, no python invocation. (#22)
+    """
+    write_formula_info(mock_env, "wget", "1.25.0")
+    # `evil; rm -rf /` would pass through the old code; the regex must catch it.
+    write_deps(mock_env, "wget", ["evil; rm -rf /"])
+
+    stub = make_cve_stub(tmp_path)
+
+    result = run_safe_install(
+        ["wget"],
+        env_extra={"DEPENDENCY_SECURITY_CHECK": str(stub)},
+        input_text="n\n",
+    )
+    assert "[skip-dep] evil; rm -rf / -- invalid name" in result.stdout
+    # Critical: no [VULN-DEP] / [ok-dep] / [HOLD-DEP] line for this name.
+    assert "[ok-dep] evil" not in result.stdout
+    assert "[VULN-DEP] evil" not in result.stdout
+
+
+def test_tap_dep_skips_age_check_with_clear_log_line(mock_env, tmp_path):
+    """
+    A tap-namespaced dep (foo/bar/baz) must skip the age check explicitly
+    with [skip-dep-age], not silently bypass it. (#23)
+    """
+    write_formula_info(mock_env, "wget", "1.25.0")
+    write_formula_info(mock_env, "foo/bar/baz", "1.0.0")
+    write_deps(mock_env, "wget", ["foo/bar/baz"])
+    # baz not installed → incoming
+
+    stub = make_cve_stub(tmp_path)
+
+    result = run_safe_install(
+        ["wget", "--min-age", "30"],
+        env_extra={"DEPENDENCY_SECURITY_CHECK": str(stub)},
+        input_text="n\n",
+    )
+    assert "[skip-dep-age] foo/bar/baz" in result.stdout
+    # CVE check still runs even though age is skipped
+    assert "[ok-dep] foo/bar/baz 1.0.0" in result.stdout
+
+
+def test_warning_splits_vuln_and_hold_into_separate_sections(mock_env, tmp_path):
+    """
+    When both a vulnerable dep AND a too-fresh dep land in the same run, the
+    warning output must show two distinct sections — not one combined header. (#24)
+
+    The age check requires real GitHub API calls, which we don't mock; this
+    test focuses on the case where ONLY a vulnerable dep is present and asserts
+    the new header text. The HOLD-only header is exercised manually.
+    """
+    write_formula_info(mock_env, "wget", "1.25.0")
+    write_formula_info(mock_env, "libfoo", "1.2.3")
+    write_deps(mock_env, "wget", ["libfoo"])
+
+    stub = make_cve_stub(
+        tmp_path,
+        per_package={"libfoo": (1, '{"status":"vulnerable"}', "[HIGH] CVE-2026-99999")},
+    )
+
+    result = run_safe_install(
+        ["wget"],
+        env_extra={"DEPENDENCY_SECURITY_CHECK": str(stub)},
+        input_text="n\n",
+    )
+    # New header text — distinguishes vulnerable from too-fresh
+    assert "WARNING: incoming dependencies have known CVEs:" in result.stdout
+    # Old conflated header must NOT appear
+    assert "WARNING: incoming dependencies have known issues" not in result.stdout
 
 
 # ----------------------- safe-upgrade --yes bypass -----------------------
@@ -298,12 +403,12 @@ def test_yes_flag_continues_past_vuln_dep_with_stderr_warning(mock_env, tmp_path
 
     # Dep was correctly flagged
     assert "[VULN-DEP] libfoo 1.2.3" in result.stdout
-    assert "WARNING: incoming dependencies have known issues" in result.stdout
+    assert "WARNING: incoming dependencies have known CVEs" in result.stdout
 
     # The bypass notice must be on STDERR (not stdout) so it survives `>/dev/null`
     # and is conspicuous in CI log streams.
-    assert "[--yes] continuing despite dep CVE warnings" in result.stderr
-    assert "[--yes] continuing despite dep CVE warnings" not in result.stdout
+    assert "[--yes] continuing despite dep warnings" in result.stderr
+    assert "[--yes] continuing despite dep warnings" not in result.stdout
 
     # The script reached the final "Done." line — i.e. upgrade was attempted.
     assert "Done." in result.stdout


### PR DESCRIPTION
## Summary

Hardening pass on the transitive dependency check shipped in v0.1.0. All changes are internal correctness and defense-in-depth; no flag/env-var surface change, no behaviour change for clean inputs.

Closes #19, #20, #22, #23, #24. Closes #21 (no code change — design rationale documented in-code).

## What changed

- `brew list --versions` parsing now uses `awk '$NF'` so multi-keg installations compare against the newest version rather than the first.
- `INCOMING_DEPS` is now a proper bash array; iteration uses quoted `"${ARR[@]}"` so whitespace in pathological tap dep names survives dedup + iteration.
- `--min-age` for tap-namespaced deps emits a `[skip-dep-age]` log line instead of relying on the GitHub homebrew-core lookup that doesn't apply to taps.
- Dep names are validated against `^[a-zA-Z0-9@._/-]+\$` before being interpolated into any URL or subprocess argument. The same regex now also guards the **main-package** age check in both scripts.
- Pre-install/pre-upgrade warning split into two distinct sections — one for known CVEs, one for `--min-age` holds — so the two risk signals are no longer conflated under a single header.
- `safe-upgrade --yes` stderr message reworded to cover both signals.
- In-code design note explains why transitive deps deliberately don't get the CVE-aware `--min-age` bypass that applies to the user-named package (closes #21 as by-design).

## Test plan

- [x] 4 new pytest cases: multi-keg classification, invalid dep-name rejection, tap-dep age skip, split warning header
- [x] All 15 tests pass locally (11 prior + 4 new)
- [x] `shellcheck` clean on all three bash scripts
- [x] Manual: `brew safe-install` usage text unchanged; `brew safe-upgrade` flag handling unchanged

## Release plan

Tag `v0.1.1` after merge — bug-fix release, no API change. Signed tag this time so the YubiKey touch becomes the explicit "I authorize this release" act.

🤖 Generated with [Claude Code](https://claude.com/claude-code)