### PR TITLE
fix: prevent NVD false positives from substring package name matches

### DIFF
--- a/dependency_security_check.py
+++ b/dependency_security_check.py
@@ -310,11 +310,18 @@ def query_nvd(package_name, ecosystem, version=None):
             if desc.strip().startswith("** DISPUTED **"):
                 continue
 
-            # Filter out CVEs that mention the keyword but are about different software
+            # Filter out CVEs that mention the keyword but are about different software.
+            # Use boundary matching that prevents "claude-code" from matching
+            # "claude-code-router" — hyphens connect compound package names, so
+            # the match must not be followed or preceded by [-\w].
             desc_lower = desc.lower()
             pkg_lower = package_name.lower()
+            pkg_nodash = pkg_lower.replace("-", "")
 
-            if pkg_lower not in desc_lower and pkg_lower.replace("-", "") not in desc_lower:
+            pkg_re = re.compile(r"(?<![a-z0-9\-])" + re.escape(pkg_lower) + r"(?![a-z0-9\-])")
+            pkg_nodash_re = re.compile(r"(?<![a-z0-9])" + re.escape(pkg_nodash) + r"(?![a-z0-9])")
+
+            if not pkg_re.search(desc_lower) and not pkg_nodash_re.search(desc_lower):
                 continue
 
             # Reject if the first sentence names a different product as the subject
@@ -326,10 +333,11 @@ def query_nvd(package_name, ecosystem, version=None):
                 .strip()
             )
             first_word = first_sentence.split()[0] if first_sentence.split() else ""
+            first_lower = first_word.lower()
             if (
-                first_word.lower() != pkg_lower
-                and first_word.lower() != pkg_lower.replace("-", "")
-                and pkg_lower not in first_word.lower()
+                first_lower != pkg_lower
+                and first_lower != pkg_nodash
+                and not pkg_re.search(first_lower)
             ):
                 continue
 


### PR DESCRIPTION
## Summary
- `query_nvd()` used plain Python substring checks to filter CVEs, which let a shorter package name match inside a longer hyphenated one.
- Concrete failure: `claude-code` matched inside `claude-code-router`, surfacing CVE-2025-57755 against `claude-code` even though it only affects `claude-code-router`.
- Replaced the substring tests with regex using negative lookbehind/lookahead over `[a-z0-9-]` so the package name only matches as its own token.

## Why this matters for `brew`
For the `brew` ecosystem, OSV and GitHub Advisory are both mapped to `None` in `ECOSYSTEM_MAP`, so only the NVD keyword search runs. A bad keyword filter directly causes false-positive blocks during `brew safe-upgrade`.

## Reference
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-57755 — affects `claude-code-router`, not `claude-code`
- CWE-200, CWE-942 — patched in `claude-code-router` v1.0.34

## Test plan
- [x] `python3 dependency_security_check.py brew claude-code 2.1.112` → CLEAN (was: false positive VULN)
- [x] `python3 dependency_security_check.py npm claude-code-router 1.0.33` → VULN (correct, pre-patch)
- [ ] Reviewer: spot-check another short package name that previously triggered substring matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)