### PR TITLE
fix: parse "prior to version X.Y.Z" patterns in NVD description fallback

### DIFF
--- a/dependency_security_check.py
+++ b/dependency_security_check.py
@@ -433,16 +433,41 @@ def query_nvd(package_name, ecosystem, version=None):
                 if has_any_cpe and not has_cpe:
                     continue
 
-                # Fallback: if no CPE data, try to extract version range from description
+                # Fallback: if no CPE data, try to extract version range from description.
+                # GitHub-style advisories often read "Starting in version X and prior to
+                # version Y" — handle the optional "version"/"v" prefix and inclusive vs
+                # exclusive boundaries.
                 if not has_cpe:
-                    # Match patterns like "through X.Y.Z", "before X.Y.Z", "up to X.Y.Z"
-                    end_match = re.search(
-                        r"(?:through|before|up to|prior to)\s+([\d]+(?:\.[\d]+)*)", desc
+                    v_re = r"(?:version\s+)?v?([\d]+(?:\.[\d]+)*)"
+
+                    # Exclusive upper bound: fixed at the matched version
+                    end_exc = re.search(
+                        rf"(?:before|prior to|fixed in|patched in)\s+{v_re}",
+                        desc,
+                        re.IGNORECASE,
                     )
-                    if end_match:
-                        upper = parse_version(end_match.group(1))
+                    if end_exc:
+                        upper = parse_version(end_exc.group(1))
+                        if upper and parse_version(version) >= upper:
+                            continue  # version is at or above the fix — not affected
+
+                    # Inclusive upper bound: last affected version
+                    end_inc = re.search(rf"\bthrough\s+{v_re}", desc, re.IGNORECASE)
+                    if end_inc:
+                        upper = parse_version(end_inc.group(1))
                         if upper and parse_version(version) > upper:
-                            continue  # Our version is above the affected range
+                            continue
+
+                    # Lower bound: affected starts at this version
+                    start_inc = re.search(
+                        rf"(?:starting in|introduced in|since)\s+{v_re}",
+                        desc,
+                        re.IGNORECASE,
+                    )
+                    if start_inc:
+                        lower = parse_version(start_inc.group(1))
+                        if lower and parse_version(version) < lower:
+                            continue
 
             findings.append(
                 {


### PR DESCRIPTION
## Summary
Fixes false-positive CVE flagging when an NVD entry has no CPE configurations and the script falls back to parsing the description text. Reproduced live with `brew safe-upgrade` blocking Hugo 0.161.0 on CVE-2024-32875 (fixed in 0.125.3) and CVE-2024-55601 (fixed in 0.139.4) — both two years out of date.

## Root cause
Two bugs in the `query_nvd` description fallback:
1. Regex `(?:through|before|prior to)\s+([\d]+...)` required a digit immediately after the keyword, so `prior to version 0.125.3` never matched (the literal word "version" was in the way).
2. Comparison used `>` instead of `>=`, so the fixed version itself stayed flagged.

## Fix
- Broadened the regex to consume an optional `version`/`v` prefix.
- Split bound semantics:
  - `before` / `prior to` / `fixed in` / `patched in` → exclusive (skip when `version >= upper`)
  - `through` → inclusive (skip when `version > upper`)
- Added a lower-bound matcher (`starting in` / `introduced in` / `since`) so versions below the affected range are also cleared.

## Test plan
- [x] `brew hugo 0.161.0` → clean (was: 2 false positives blocking the upgrade)
- [x] `brew hugo 0.124.0` → still flags CVE-2024-32875 and CVE-2024-55601
- [x] `brew hugo 0.130.0` → flags only CVE-2024-55601 (correctly clears CVE-2024-32875 since 0.130 > 0.125.3 fix)

## Note
A parallel fix landed in `sharkyger/claude-code-security#3` against the copy of this script in that repo. This PR carries only the surgical change to the NVD description-parsing fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)