### PR TITLE
chore: default --min-age to 3 days for formulae

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The project is pre-1.0; expect minor breaking changes between 0.x releases until
 
 ## [Unreleased]
 
+### Changed
+- **Default `--min-age` is now 3 days** (was 0 = disabled) for both `brew-safe-install` and `brew-safe-upgrade`. The freshness hold applies to formulae only; casks remain unaffected (brew enforces the SHA256 recorded in the cask file on every install, so the supply-chain shape is different). Use `--min-age 0` to restore the previous behaviour. Motivation: recurring npm worm campaigns (Shai-Hulud, Mini Shai-Hulud) compromise packages for live windows of 1–6 hours before takedown — too short for CVE databases to react. A multi-day freshness hold trades a small upgrade lag against the entire attack window. The CVE-aware bypass that skips the age check when the *installed* version has known CVEs is unchanged, so security patches still reach you immediately.
+
 ## [0.1.1] — 2026-04-26
 
 Hardening pass following the v0.1.0 review. All changes are internal correctness and defense-in-depth improvements; the public flag/env-var surface is unchanged.

--- a/README.md
+++ b/README.md
@@ -143,12 +143,13 @@ The flag is per-invocation by design — the safe default always returns the nex
 
 > **Note on big upgrade batches.** `brew safe-upgrade` deduplicates incoming deps across the batch, but a large run with many unique deps can still hit NIST NVD's anonymous rate limit (5 requests / 30 seconds). When that happens you'll see `[skip-dep]` lines in the output — those deps were not vetted. Re-run the upgrade later, or pass `--no-deps` if you've vetted upstream another way.
 
-### Minimum-age check (opt-in)
+### Minimum-age check (on by default, 3 days)
 
-Hold back packages published less than N days ago. Protects against supply chain attacks where a compromised version is published minutes after credential theft — before any CVE database knows about it.
+Hold back formulae published less than N days ago. Protects against supply chain attacks where a compromised version is published minutes after credential theft — before any CVE database knows about it. Worm-class npm compromises (Shai-Hulud, Mini Shai-Hulud) have repeatedly shown live windows of 1–6 hours between malicious publish and registry takedown; a multi-day freshness hold trades a small lag against the entire attack window.
 
 ```
-brew safe-upgrade --min-age 3
+brew safe-upgrade            # uses default --min-age 3
+brew safe-upgrade --min-age 7 # stricter
 ```
 
 ```
@@ -161,9 +162,9 @@ Checking package age (min-age: 3 days)...
 
 **CVE-aware bypass:** If your *installed* version has known CVEs, the age check is skipped — the fresh version is likely the fix, and holding it back would leave you exposed. This means `--min-age` never prevents security patches from reaching you.
 
-Use `--min-age 0` to disable (default behavior).
+**Casks are not age-gated.** The check applies to formulae only. Casks point at vendor-hosted binaries with their own signing, and brew enforces the SHA256 recorded in the cask file on every install — the supply-chain attack surface is narrower than for formulae.
 
-> **What should the default be?** We ship with off by default (opt-in). The community is discussing whether it should be on by default: [Discussion #14](https://github.com/sharkyger/homebrew-safe-upgrade/discussions/14)
+Use `--min-age 0` to disable.
 
 ### SHA verification (opt-in)
 
@@ -212,7 +213,8 @@ Install wget imagemagick? [Y/n]
 Supports the same `--min-age`, `--verify-sha`, and `--no-deps` flags:
 
 ```
-brew safe-install --min-age 3 wget curl
+brew safe-install wget curl               # default --min-age 3
+brew safe-install --min-age 7 wget curl   # stricter
 brew safe-install --verify-sha --cask firefox
 brew safe-install --no-deps wget          # skip transitive dep check
 ```

--- a/brew-safe-install
+++ b/brew-safe-install
@@ -4,7 +4,7 @@
 # Queries 3 databases: OSV.dev, GitHub Advisory, NIST NVD.
 #
 # Usage: brew safe-install [flags] package1 [package2 ...]
-#        --min-age N     Hold packages published less than N days ago (default: 0 = off)
+#        --min-age N     Hold packages published less than N days ago (default: 3; --min-age 0 to disable)
 #        --verify-sha    Verify bottle SHA against formulae.brew.sh API
 #        --no-deps       Skip transitive dependency checking (default: check)
 #
@@ -28,7 +28,7 @@ fi
 # Separate our flags, brew flags, and package names
 BREW_FLAGS=""
 PACKAGES=""
-MIN_AGE=0
+MIN_AGE=3          # 3-day freshness hold for formulae; --min-age 0 to disable.
 VERIFY_SHA=false
 CHECK_DEPS=true
 case "${BREW_SAFE_NO_DEPS:-}" in
@@ -51,7 +51,7 @@ if [ -z "$PACKAGES" ]; then
     echo "Usage: brew safe-install [flags] package1 [package2 ...]"
     echo ""
     echo "Options:"
-    echo "  --min-age N     Hold packages published less than N days ago (default: 0 = off)"
+    echo "  --min-age N     Hold packages published less than N days ago (default: 3; --min-age 0 to disable)"
     echo "  --verify-sha    Verify bottle SHA against formulae.brew.sh API"
     echo "  --no-deps       Skip transitive dependency checking (default: check)"
     echo "                  Or set BREW_SAFE_NO_DEPS=1 in your environment."
@@ -127,7 +127,7 @@ except Exception:
         continue
     fi
 
-    # --- Min-age check (opt-in) ---
+    # --- Min-age check (default: 3 days; --min-age 0 to disable) ---
     # Defense in depth: only allow Homebrew-shaped names through the URL we
     # construct from `brew info` output.
     if [ "$MIN_AGE" -gt 0 ] 2>/dev/null && [ "$PKG_TYPE" = "formula" ] && [[ "$BARE_NAME" =~ ^[a-zA-Z0-9@._/-]+$ ]]; then

--- a/brew-safe-upgrade
+++ b/brew-safe-upgrade
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="${DEPENDENCY_SECURITY_CHECK:-$SCRIPT_DIR/dependency_security_check.py}"
 
 AUTO_YES=false
-MIN_AGE=0          # 0 = disabled (opt-in). Use --min-age N to enable.
+MIN_AGE=3          # 3-day freshness hold for formulae; --min-age 0 to disable.
 VERIFY_SHA=false
 CHECK_DEPS=true
 case "${BREW_SAFE_NO_DEPS:-}" in
@@ -107,7 +107,7 @@ if [ -n "$OUTDATED_CASKS" ]; then
     [ -n "$OUTDATED" ] && OUTDATED="$OUTDATED"$'\n'"$OUTDATED_CASKS" || OUTDATED="$OUTDATED_CASKS"
 fi
 
-# --- Min-age check (opt-in) ---
+# --- Min-age check (default: 3 days; --min-age 0 to disable) ---
 HELD_PKGS=""
 HELD_COUNT=0
 


### PR DESCRIPTION
## Summary

- Flip `MIN_AGE` default from 0 (disabled) to 3 days in `brew-safe-install` and `brew-safe-upgrade`.
- Affects formulae only — casks are not age-gated (brew enforces the cask-file SHA256 on every install).
- The CVE-aware bypass that skips the age check when the *installed* version has known CVEs is unchanged, so security patches still reach users immediately.

## Motivation

Recurring npm worm campaigns (Shai-Hulud 2025, Mini Shai-Hulud / TanStack May 2026) compromise packages for live windows of 1–6 hours between malicious publish and registry takedown — far too short for CVE databases (NVD, GHSA, OSV) to react. A multi-day freshness hold sits across that entire window at the cost of a small upgrade lag.

Brew's formula PR-review model raises the bar versus npm, but the supply-chain risk is non-zero and the cost of a default-on freshness hold for formulae is small.

## Backward compatibility

Pre-1.0 default change. Users relying on immediate-formula behaviour can restore it with `--min-age 0` per invocation or via shell alias. Documented in CHANGELOG `[Unreleased] → Changed`.

## Test plan

- [x] `pytest tests/` — 21 passed locally
- [x] `bash brew-safe-install` (no args) — help output reflects new default
- [x] Subagent code review of the diff — approved with two nits, both fixed
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)