### PR TITLE
feat: SHA verification is now default-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The project is pre-1.0; expect minor breaking changes between 0.x releases until
 ## [Unreleased]
 
 ### Changed
+- **SHA verification is now default-on** for both `brew-safe-install` and `brew-safe-upgrade`. The bottle SHA from `brew info --json=v2` is compared against the canonical SHA published at `formulae.brew.sh`. Five outcomes:
+  - **Match** — `[sha] verified <local>=<canonical>`, install/upgrade proceeds.
+  - **Mismatch** — `[BLOCKED] SHA mismatch` with both full fingerprints printed; the package is excluded from the install/upgrade set and the script exits non-zero. **Tampering is never overridable by `--yes`** — it's a deliberate security signal that must surface in CI/pipelines.
+  - **No bottle** — `[sha] no bottle — built from source`, proceeds (canonical formula exists but isn't bottled).
+  - **Tap-only / 404** — `[sha] tap-only formula — no canonical SHA available`, proceeds without a prompt (third-party taps don't publish to formulae.brew.sh).
+  - **Canonical API 5xx / timeout** — batched into a single end-of-loop prompt. Interactive: `[WARN] formulae.brew.sh unreachable... Install anyway? [y/N]`. Non-interactive or `--yes`: warn loudly and continue (so the script doesn't hang in CI).
+
+  Opt out with `--no-verify-sha`. The previous `--verify-sha` flag is accepted as a silent no-op for backward compatibility.
+
+  Motivation: defense in depth alongside the existing CVE check + freshness hold. If a tap or mirror is compromised and ships a tampered bottle with the same version number, the SHA divergence from formulae.brew.sh's canonical record is the first signal — long before CVE databases register the incident.
+
 - **Default `--min-age` is now 3 days** (was 0 = disabled) for both `brew-safe-install` and `brew-safe-upgrade`. The freshness hold applies to formulae only; casks remain unaffected (brew enforces the SHA256 recorded in the cask file on every install, so the supply-chain shape is different). Use `--min-age 0` to restore the previous behaviour. Motivation: recurring npm worm campaigns (Shai-Hulud, Mini Shai-Hulud) compromise packages for live windows of 1–6 hours before takedown — too short for CVE databases to react. A multi-day freshness hold trades a small upgrade lag against the entire attack window. The CVE-aware bypass that skips the age check when the *installed* version has known CVEs is unchanged, so security patches still reach you immediately.
 
 ## [0.1.1] — 2026-04-26

--- a/README.md
+++ b/README.md
@@ -166,20 +166,33 @@ Checking package age (min-age: 3 days)...
 
 Use `--min-age 0` to disable.
 
-### SHA verification (opt-in)
+### SHA verification (default ON)
 
-Verify bottle checksums against the Homebrew formulae API before upgrading. Detects local tap tampering.
-
-```
-brew safe-upgrade --verify-sha
-```
+Both `brew-safe-install` and `brew-safe-upgrade` compare the local-tap bottle SHA (from `brew info --json=v2`) against the canonical SHA published at `formulae.brew.sh`. Tampered taps that ship a bottle with the same version number but a different SHA are blocked before brew sees them.
 
 ```
   [ok] gh 2.91.0
-    [sha] ea543daa28d39acc... verified via formulae.brew.sh
+    [sha] ea543daa28d39acc=ea543daa28d39acc
 ```
 
-Note: Homebrew already verifies bottle SHAs during install. This adds a pre-upgrade check against the remote API as an independent verification. Advisory only — never blocks.
+Five outcomes, all logged distinctly:
+
+| Outcome | Output | Exit behaviour |
+|---|---|---|
+| **Match** | `[sha] verified <local>=<canonical>` | install/upgrade proceeds |
+| **Mismatch** | `[BLOCKED] SHA mismatch` + both full fingerprints | package excluded, script exits non-zero; **`--yes` never overrides this** |
+| **No bottle** | `[sha] no bottle — built from source` | proceeds (canonical formula exists, isn't bottled) |
+| **Tap-only / 404** | `[sha] tap-only formula — no canonical SHA available` | proceeds without prompt (third-party taps) |
+| **API 5xx / timeout** | end-of-loop `[WARN] formulae.brew.sh unreachable... Install anyway? [y/N]` | interactive: prompt once for all; `--yes` / non-TTY: warn and continue |
+
+Opt out with `--no-verify-sha` if you trust your tap and want the older behaviour back:
+
+```
+brew safe-install --no-verify-sha wget
+brew safe-upgrade --no-verify-sha
+```
+
+Casks are out of scope — brew already enforces the cask-file SHA on every install, so duplicating that check here adds no signal.
 
 ## brew safe-install
 
@@ -210,12 +223,12 @@ Install wget imagemagick? [Y/n]
 ```
 
 
-Supports the same `--min-age`, `--verify-sha`, and `--no-deps` flags:
+Supports the same `--min-age`, `--no-verify-sha`, and `--no-deps` flags:
 
 ```
-brew safe-install wget curl               # default --min-age 3
+brew safe-install wget curl               # default --min-age 3, SHA verify on
 brew safe-install --min-age 7 wget curl   # stricter
-brew safe-install --verify-sha --cask firefox
+brew safe-install --no-verify-sha wget    # skip SHA check (e.g. on slow networks)
 brew safe-install --no-deps wget          # skip transitive dep check
 ```
 

--- a/brew-safe-install
+++ b/brew-safe-install
@@ -4,12 +4,16 @@
 # Queries 3 databases: OSV.dev, GitHub Advisory, NIST NVD.
 #
 # Usage: brew safe-install [flags] package1 [package2 ...]
-#        --min-age N     Hold packages published less than N days ago (default: 3; --min-age 0 to disable)
-#        --verify-sha    Verify bottle SHA against formulae.brew.sh API
-#        --no-deps       Skip transitive dependency checking (default: check)
+#        --min-age N      Hold packages published less than N days ago (default: 3; --min-age 0 to disable)
+#        --no-verify-sha  Skip bottle SHA verification against formulae.brew.sh (default: ON)
+#        --no-deps        Skip transitive dependency checking (default: check)
 #
 # Environment:
-#        BREW_SAFE_NO_DEPS=1   Same as --no-deps (handy for CI / aliases)
+#        BREW_SAFE_NO_DEPS=1     Same as --no-deps (handy for CI / aliases)
+#        MOCK_FORMULAE_API_DIR   (test only) read canonical responses from this dir
+#                                instead of curling https://formulae.brew.sh
+#        MOCK_INTERACTIVE_MODE=1 (test only) force the interactive prompt branch
+#                                even when stdin is not a TTY
 
 set -uo pipefail
 
@@ -29,7 +33,7 @@ fi
 BREW_FLAGS=""
 PACKAGES=""
 MIN_AGE=3          # 3-day freshness hold for formulae; --min-age 0 to disable.
-VERIFY_SHA=false
+VERIFY_SHA=true    # Default-on as of v0.2.0 — opt out with --no-verify-sha.
 CHECK_DEPS=true
 case "${BREW_SAFE_NO_DEPS:-}" in
     1|true|TRUE|yes|YES) CHECK_DEPS=false ;;
@@ -37,11 +41,12 @@ esac
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --min-age)    MIN_AGE="${2:-0}"; shift 2 ;;
-        --verify-sha) VERIFY_SHA=true; shift ;;
-        --no-deps)    CHECK_DEPS=false; shift ;;
-        -*)           BREW_FLAGS="$BREW_FLAGS $1"; shift ;;
-        *)            PACKAGES="$PACKAGES $1"; shift ;;
+        --min-age)       MIN_AGE="${2:-0}"; shift 2 ;;
+        --verify-sha)    shift ;;  # Accepted for back-compat — verification is now on by default.
+        --no-verify-sha) VERIFY_SHA=false; shift ;;
+        --no-deps)       CHECK_DEPS=false; shift ;;
+        -*)              BREW_FLAGS="$BREW_FLAGS $1"; shift ;;
+        *)               PACKAGES="$PACKAGES $1"; shift ;;
     esac
 done
 
@@ -51,10 +56,10 @@ if [ -z "$PACKAGES" ]; then
     echo "Usage: brew safe-install [flags] package1 [package2 ...]"
     echo ""
     echo "Options:"
-    echo "  --min-age N     Hold packages published less than N days ago (default: 3; --min-age 0 to disable)"
-    echo "  --verify-sha    Verify bottle SHA against formulae.brew.sh API"
-    echo "  --no-deps       Skip transitive dependency checking (default: check)"
-    echo "                  Or set BREW_SAFE_NO_DEPS=1 in your environment."
+    echo "  --min-age N      Hold packages published less than N days ago (default: 3; --min-age 0 to disable)"
+    echo "  --no-verify-sha  Skip bottle SHA verification against formulae.brew.sh (default: ON)"
+    echo "  --no-deps        Skip transitive dependency checking (default: check)"
+    echo "                   Or set BREW_SAFE_NO_DEPS=1 in your environment."
     echo "  All other flags are passed through to brew install."
     exit 2
 fi
@@ -63,11 +68,13 @@ echo "Resolving package versions..."
 echo ""
 
 BLOCKED_PKGS=""
+TAMPERED_PKGS=""
 SKIPPED_PKGS=""
 HELD_PKGS=""
 CLEAN_PKGS=""
 CLEAN_COUNT=0
 PKG_COUNT=0
+SHA_API_ERROR_PKGS=""
 
 for pkg in $PACKAGES; do
     PKG_COUNT=$((PKG_COUNT + 1))
@@ -167,38 +174,129 @@ except Exception:
     RESULT=$(python3 "$SCRIPT" brew "$BARE_NAME" "$VERSION" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
 
     if [ "$EXIT_CODE" -eq 0 ]; then
-        echo "  [ok] $pkg $VERSION"
-        CLEAN_PKGS="$CLEAN_PKGS $pkg"
-        CLEAN_COUNT=$((CLEAN_COUNT + 1))
-
-        # --- SHA verification (opt-in) ---
-        if [ "$VERIFY_SHA" = true ] && [ "$PKG_TYPE" = "formula" ]; then
-            SHA_RESULT=$(curl -sf "https://formulae.brew.sh/api/formula/${BARE_NAME}.json" 2>/dev/null | python3 -c "
+        # --- SHA verification (default ON; --no-verify-sha to opt out) ---
+        # Test escape hatches honored:
+        #   MOCK_FORMULAE_API_DIR  — read canonical from filesystem instead of curl
+        #   MOCK_INTERACTIVE_MODE  — handled at the end-of-loop batch prompt, not here
+        # Five outcomes (and three are silent-pass for the verdict tracking):
+        #   match      -> "[sha] verified ...", verdict=match
+        #   mismatch   -> "[BLOCKED] SHA mismatch ...", verdict=mismatch (tampering — never overridable)
+        #   no_bottle  -> "[sha] no bottle — built from source", verdict=no_bottle
+        #   tap_only   -> "[sha] tap-only formula — no canonical SHA available", verdict=tap_only
+        #   api_error  -> queued into SHA_API_ERROR_PKGS for a single batch prompt at end of loop
+        SHA_VERDICT="skip"
+        if [ "$VERIFY_SHA" = true ]; then
+            if [ "$PKG_TYPE" = "cask" ]; then
+                echo "    [sha] casks not in scope — brew enforces cask-file SHA at install"
+                SHA_VERDICT="cask"
+            else
+                # 1. Extract local SHA from the same `brew info` payload we already fetched.
+                LOCAL_SHA=$(echo "$INFO_JSON" | python3 -c "
 import sys, json
 try:
-    data = json.load(sys.stdin)
-    bottle = data.get('bottle', {}).get('stable', {})
-    files = bottle.get('files', {})
-    for platform, info in files.items():
-        sha = info.get('sha256', '')
-        if sha:
-            print(f'sha_ok {sha[:16]} {platform}')
-            break
-    else:
-        print('no_bottle')
+    d = json.load(sys.stdin)
+    f = d.get('formulae', [])
+    if f:
+        files = f[0].get('bottle', {}).get('stable', {}).get('files', {})
+        for plat, info in files.items():
+            sha = info.get('sha256', '')
+            if sha:
+                print(sha)
+                break
 except Exception:
-    print('error')
+    pass
 " 2>/dev/null)
 
-            SHA_STATUS=$(echo "$SHA_RESULT" | awk '{print $1}')
-            if [ "$SHA_STATUS" = "sha_ok" ]; then
-                SHA_SHORT=$(echo "$SHA_RESULT" | awk '{print $2}')
-                echo "    [sha] ${SHA_SHORT}... verified via formulae.brew.sh"
-            elif [ "$SHA_STATUS" = "no_bottle" ]; then
-                echo "    [sha] no bottle found — built from source"
-            else
-                echo "    [sha] could not verify — API unavailable"
+                # 2. Fetch canonical from formulae.brew.sh — or from the test mock dir.
+                if [ -n "${MOCK_FORMULAE_API_DIR:-}" ]; then
+                    MOCK_FILE="$MOCK_FORMULAE_API_DIR/${BARE_NAME}.json"
+                    if [ ! -f "$MOCK_FILE" ]; then
+                        SHA_HTTP_CODE=404
+                        CANON_JSON=""
+                    elif grep -q "__SIMULATE_API_ERROR__" "$MOCK_FILE"; then
+                        SHA_HTTP_CODE=503
+                        CANON_JSON=""
+                    else
+                        SHA_HTTP_CODE=200
+                        CANON_JSON=$(cat "$MOCK_FILE")
+                    fi
+                else
+                    CANON_TMP=$(mktemp)
+                    SHA_HTTP_CODE=$(curl -s -o "$CANON_TMP" -w "%{http_code}" --max-time 10 \
+                        "https://formulae.brew.sh/api/formula/${BARE_NAME}.json" 2>/dev/null || echo "000")
+                    CANON_JSON=$(cat "$CANON_TMP" 2>/dev/null || echo "")
+                    rm -f "$CANON_TMP"
+                fi
+
+                # If the local tap has no bottle (built --from-source, or a tap
+                # that never ships bottles), there is nothing to compare against
+                # the canonical record — treat as no-bottle, not as tampering.
+                if [ -z "$LOCAL_SHA" ]; then
+                    echo "    [sha] no local bottle — built from source, skipping canonical check"
+                    SHA_VERDICT="no_bottle"
+                    SHA_HTTP_CODE="SKIP"
+                fi
+
+                # 3. Classify by HTTP code + canonical payload.
+                case "$SHA_HTTP_CODE" in
+                    SKIP) : ;;
+                    200)
+                        CANON_SHA=$(echo "$CANON_JSON" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    files = d.get('bottle', {}).get('stable', {}).get('files', {})
+    if not files:
+        print('NO_BOTTLE')
+    else:
+        for plat, info in files.items():
+            sha = info.get('sha256', '')
+            if sha:
+                print(sha)
+                break
+        else:
+            print('NO_BOTTLE')
+except Exception:
+    print('PARSE_ERROR')
+" 2>/dev/null)
+                        if [ "$CANON_SHA" = "NO_BOTTLE" ]; then
+                            echo "    [sha] no bottle — built from source"
+                            SHA_VERDICT="no_bottle"
+                        elif [ "$CANON_SHA" = "PARSE_ERROR" ] || [ -z "$CANON_SHA" ]; then
+                            SHA_API_ERROR_PKGS="$SHA_API_ERROR_PKGS $pkg"
+                            SHA_VERDICT="api_error"
+                        elif [ "$LOCAL_SHA" = "$CANON_SHA" ]; then
+                            echo "    [sha] verified ${LOCAL_SHA:0:16}=${CANON_SHA:0:16}"
+                            SHA_VERDICT="match"
+                        else
+                            # Tampering — print BOTH full fingerprints so the user can verify themselves.
+                            echo "    [BLOCKED] SHA mismatch for $pkg"
+                            echo "      local     : $LOCAL_SHA"
+                            echo "      canonical : $CANON_SHA"
+                            TAMPERED_PKGS="$TAMPERED_PKGS $pkg"
+                            SHA_VERDICT="mismatch"
+                        fi
+                        ;;
+                    404)
+                        echo "    [sha] tap-only formula — no canonical SHA available"
+                        SHA_VERDICT="tap_only"
+                        ;;
+                    *)
+                        # 5xx, timeout, curl failure (000), or other non-200 — collect for batch.
+                        SHA_API_ERROR_PKGS="$SHA_API_ERROR_PKGS $pkg"
+                        SHA_VERDICT="api_error"
+                        ;;
+                esac
             fi
+        fi
+
+        # Only add to CLEAN_PKGS if SHA didn't flag tampering — tampering is non-overridable.
+        if [ "$SHA_VERDICT" = "mismatch" ]; then
+            : # already echoed [BLOCKED] above; do not add to CLEAN_PKGS
+        else
+            echo "  [ok] $pkg $VERSION"
+            CLEAN_PKGS="$CLEAN_PKGS $pkg"
+            CLEAN_COUNT=$((CLEAN_COUNT + 1))
         fi
     elif [ "$EXIT_CODE" -eq 1 ]; then
         echo "  [VULN] $pkg $VERSION -- vulnerabilities found!"
@@ -210,11 +308,41 @@ except Exception:
     fi
 done
 
+# --- SHA batch error prompt ---
+# If any packages had unreachable canonical SHA, decide once whether to proceed.
+# Interactive (TTY or MOCK_INTERACTIVE_MODE=1): single prompt for all of them.
+# Non-interactive: warn loudly and continue.
+if [ -n "$SHA_API_ERROR_PKGS" ]; then
+    SHA_API_ERROR_PKGS_TRIMMED=$(echo "$SHA_API_ERROR_PKGS" | xargs)
+    echo ""
+    echo "[WARN] formulae.brew.sh unreachable for SHA verification: $SHA_API_ERROR_PKGS_TRIMMED"
+    SHA_IS_INTERACTIVE=false
+    if [ "${MOCK_INTERACTIVE_MODE:-0}" = "1" ] || [ -t 0 ]; then
+        SHA_IS_INTERACTIVE=true
+    fi
+    if [ "$SHA_IS_INTERACTIVE" = true ]; then
+        # Use echo + read instead of read -rp because `-p` writes to stderr and
+        # only when stdin is a TTY. Tests check stdout, so the prompt text must
+        # be on stdout regardless.
+        echo "Install anyway? [y/N] "
+        read -r SHA_CONFIRM
+        if [[ ! "$SHA_CONFIRM" =~ ^[yY] ]]; then
+            echo "Cancelled."
+            exit 1
+        fi
+    else
+        echo "[WARN] non-interactive — continuing without SHA verification for those packages"
+    fi
+fi
+
 # Summary
 echo ""
 echo "Results: $CLEAN_COUNT clean out of $PKG_COUNT package(s)"
 if [ -n "$BLOCKED_PKGS" ]; then
     echo "  Blocked (vulnerable):$BLOCKED_PKGS"
+fi
+if [ -n "$TAMPERED_PKGS" ]; then
+    echo "  Blocked (SHA tampered):$TAMPERED_PKGS"
 fi
 if [ -n "$HELD_PKGS" ]; then
     echo "  Held (too fresh):$HELD_PKGS"
@@ -425,3 +553,10 @@ brew install $BREW_FLAGS $CLEAN_PKGS </dev/null 2>&1 || true
 
 echo ""
 echo "Done."
+
+# Exit non-zero if any tampering was detected, regardless of how many clean
+# packages installed alongside. Tampering is a security event that must surface
+# in CI / shell pipelines even when some other packages were OK.
+if [ -n "$TAMPERED_PKGS" ]; then
+    exit 1
+fi

--- a/brew-safe-upgrade
+++ b/brew-safe-upgrade
@@ -3,10 +3,14 @@
 # dependencies for known vulnerabilities before upgrading.
 # Queries 3 databases: OSV.dev, GitHub Advisory, NIST NVD.
 #
-# Usage: brew safe-upgrade [--yes|-y] [--min-age N] [--verify-sha] [--no-deps]
+# Usage: brew safe-upgrade [--yes|-y] [--min-age N] [--no-verify-sha] [--no-deps]
 #
 # Environment:
-#        BREW_SAFE_NO_DEPS=1   Same as --no-deps (handy for CI / aliases)
+#        BREW_SAFE_NO_DEPS=1     Same as --no-deps (handy for CI / aliases)
+#        MOCK_FORMULAE_API_DIR   (test only) read canonical responses from this dir
+#                                instead of curling https://formulae.brew.sh
+#        MOCK_INTERACTIVE_MODE=1 (test only) force the interactive prompt branch
+#                                even when stdin is not a TTY
 
 set -uo pipefail
 
@@ -18,7 +22,7 @@ SCRIPT="${DEPENDENCY_SECURITY_CHECK:-$SCRIPT_DIR/dependency_security_check.py}"
 
 AUTO_YES=false
 MIN_AGE=3          # 3-day freshness hold for formulae; --min-age 0 to disable.
-VERIFY_SHA=false
+VERIFY_SHA=true    # Default-on as of v0.2.0 — opt out with --no-verify-sha.
 CHECK_DEPS=true
 case "${BREW_SAFE_NO_DEPS:-}" in
     1|true|TRUE|yes|YES) CHECK_DEPS=false ;;
@@ -26,11 +30,12 @@ esac
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --yes|-y)     AUTO_YES=true; shift ;;
-        --min-age)    MIN_AGE="${2:-0}"; shift 2 ;;
-        --verify-sha) VERIFY_SHA=true; shift ;;
-        --no-deps)    CHECK_DEPS=false; shift ;;
-        *)            shift ;;
+        --yes|-y)        AUTO_YES=true; shift ;;
+        --min-age)       MIN_AGE="${2:-0}"; shift 2 ;;
+        --verify-sha)    shift ;;  # Accepted for back-compat — verification is now on by default.
+        --no-verify-sha) VERIFY_SHA=false; shift ;;
+        --no-deps)       CHECK_DEPS=false; shift ;;
+        *)               shift ;;
     esac
 done
 
@@ -189,9 +194,10 @@ echo "Running security checks..."
 echo ""
 
 BLOCKED_PKGS=""
+TAMPERED_PKGS=""
 SKIPPED_PKGS=""
 CLEAN_COUNT=0
-SHA_WARNINGS=""
+SHA_API_ERROR_PKGS=""
 
 while read -r name installed current; do
     if [ -f "$SCRIPT" ]; then
@@ -199,40 +205,128 @@ while read -r name installed current; do
         RESULT_JSON=$(python3 "$SCRIPT" brew "$name" "$current" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
 
         if [ "$EXIT_CODE" -eq 0 ]; then
-            echo "  [ok] $name $current"
-            CLEAN_COUNT=$((CLEAN_COUNT + 1))
-
-            # --- SHA verification (opt-in) ---
+            # --- SHA verification (default ON; --no-verify-sha to opt out) ---
+            # See brew-safe-install for the full contract; this block must stay symmetric.
+            SHA_VERDICT="skip"
             if [ "$VERIFY_SHA" = true ]; then
-                FIRST_LETTER=$(echo "$name" | cut -c1)
-                SHA_RESULT=$(curl -sf "https://formulae.brew.sh/api/formula/${name}.json" 2>/dev/null | python3 -c "
+                # Determine type — upgrade lists formulae and casks together.
+                PKG_INFO_JSON=$(brew info --json=v2 "$name" 2>/dev/null)
+                PKG_TYPE_HERE=$(echo "$PKG_INFO_JSON" | python3 -c "
 import sys, json
 try:
-    data = json.load(sys.stdin)
-    bottle = data.get('bottle', {}).get('stable', {})
-    files = bottle.get('files', {})
-    # Get SHA for any available platform
-    for platform, info in files.items():
-        sha = info.get('sha256', '')
-        if sha:
-            print(f'sha_ok {sha[:16]} {platform}')
-            break
+    d = json.load(sys.stdin)
+    if d.get('casks'):
+        print('cask')
     else:
-        print('no_bottle')
+        print('formula')
 except Exception:
-    print('error')
+    print('formula')
 " 2>/dev/null)
 
-                SHA_STATUS=$(echo "$SHA_RESULT" | awk '{print $1}')
-                if [ "$SHA_STATUS" = "sha_ok" ]; then
-                    SHA_SHORT=$(echo "$SHA_RESULT" | awk '{print $2}')
-                    echo "    [sha] ${SHA_SHORT}... verified via formulae.brew.sh"
-                elif [ "$SHA_STATUS" = "no_bottle" ]; then
-                    echo "    [sha] no bottle found — built from source"
+                if [ "$PKG_TYPE_HERE" = "cask" ]; then
+                    echo "    [sha] casks not in scope — brew enforces cask-file SHA at install"
+                    SHA_VERDICT="cask"
                 else
-                    echo "    [sha] could not verify — API unavailable"
-                    SHA_WARNINGS="$SHA_WARNINGS $name"
+                    LOCAL_SHA=$(echo "$PKG_INFO_JSON" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    f = d.get('formulae', [])
+    if f:
+        files = f[0].get('bottle', {}).get('stable', {}).get('files', {})
+        for plat, info in files.items():
+            sha = info.get('sha256', '')
+            if sha:
+                print(sha)
+                break
+except Exception:
+    pass
+" 2>/dev/null)
+
+                    if [ -n "${MOCK_FORMULAE_API_DIR:-}" ]; then
+                        MOCK_FILE="$MOCK_FORMULAE_API_DIR/${name}.json"
+                        if [ ! -f "$MOCK_FILE" ]; then
+                            SHA_HTTP_CODE=404
+                            CANON_JSON=""
+                        elif grep -q "__SIMULATE_API_ERROR__" "$MOCK_FILE"; then
+                            SHA_HTTP_CODE=503
+                            CANON_JSON=""
+                        else
+                            SHA_HTTP_CODE=200
+                            CANON_JSON=$(cat "$MOCK_FILE")
+                        fi
+                    else
+                        CANON_TMP=$(mktemp)
+                        SHA_HTTP_CODE=$(curl -s -o "$CANON_TMP" -w "%{http_code}" --max-time 10 \
+                            "https://formulae.brew.sh/api/formula/${name}.json" 2>/dev/null || echo "000")
+                        CANON_JSON=$(cat "$CANON_TMP" 2>/dev/null || echo "")
+                        rm -f "$CANON_TMP"
+                    fi
+
+                    # If the local tap has no bottle (built --from-source, or a tap
+                    # that never ships bottles), there is nothing to compare against
+                    # the canonical record — treat as no-bottle, not as tampering.
+                    if [ -z "$LOCAL_SHA" ]; then
+                        echo "    [sha] no local bottle — built from source, skipping canonical check"
+                        SHA_VERDICT="no_bottle"
+                        SHA_HTTP_CODE="SKIP"
+                    fi
+
+                    case "$SHA_HTTP_CODE" in
+                        SKIP) : ;;
+                        200)
+                            CANON_SHA=$(echo "$CANON_JSON" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    files = d.get('bottle', {}).get('stable', {}).get('files', {})
+    if not files:
+        print('NO_BOTTLE')
+    else:
+        for plat, info in files.items():
+            sha = info.get('sha256', '')
+            if sha:
+                print(sha)
+                break
+        else:
+            print('NO_BOTTLE')
+except Exception:
+    print('PARSE_ERROR')
+" 2>/dev/null)
+                            if [ "$CANON_SHA" = "NO_BOTTLE" ]; then
+                                echo "    [sha] no bottle — built from source"
+                                SHA_VERDICT="no_bottle"
+                            elif [ "$CANON_SHA" = "PARSE_ERROR" ] || [ -z "$CANON_SHA" ]; then
+                                SHA_API_ERROR_PKGS="$SHA_API_ERROR_PKGS $name"
+                                SHA_VERDICT="api_error"
+                            elif [ "$LOCAL_SHA" = "$CANON_SHA" ]; then
+                                echo "    [sha] verified ${LOCAL_SHA:0:16}=${CANON_SHA:0:16}"
+                                SHA_VERDICT="match"
+                            else
+                                echo "    [BLOCKED] SHA mismatch for $name"
+                                echo "      local     : $LOCAL_SHA"
+                                echo "      canonical : $CANON_SHA"
+                                TAMPERED_PKGS="$TAMPERED_PKGS $name"
+                                SHA_VERDICT="mismatch"
+                            fi
+                            ;;
+                        404)
+                            echo "    [sha] tap-only formula — no canonical SHA available"
+                            SHA_VERDICT="tap_only"
+                            ;;
+                        *)
+                            SHA_API_ERROR_PKGS="$SHA_API_ERROR_PKGS $name"
+                            SHA_VERDICT="api_error"
+                            ;;
+                    esac
                 fi
+            fi
+
+            if [ "$SHA_VERDICT" = "mismatch" ]; then
+                : # [BLOCKED] already emitted; don't count as clean. --yes never overrides this.
+            else
+                echo "  [ok] $name $current"
+                CLEAN_COUNT=$((CLEAN_COUNT + 1))
             fi
         elif [ "$EXIT_CODE" -eq 1 ]; then
             echo "  [VULN] $name $current -- vulnerabilities found!"
@@ -263,8 +357,9 @@ except Exception:
     fi
 done <<< "$OUTDATED"
 
-# Build separate clean lists for formulae and casks
-EXCLUDE_PKGS="$BLOCKED_PKGS $SKIPPED_PKGS $HELD_PKGS"
+# Build separate clean lists for formulae and casks. TAMPERED_PKGS is excluded
+# alongside BLOCKED_PKGS so brew never sees a tampered formula on its cmdline.
+EXCLUDE_PKGS="$BLOCKED_PKGS $TAMPERED_PKGS $SKIPPED_PKGS $HELD_PKGS"
 CLEAN_PKGS_FORMULAE=""
 CLEAN_PKGS_CASKS=""
 
@@ -286,11 +381,37 @@ fi
 
 CLEAN_PKGS="${CLEAN_PKGS_FORMULAE}${CLEAN_PKGS_CASKS}"
 
+# --- SHA batch error prompt (same shape as brew-safe-install) ---
+if [ -n "$SHA_API_ERROR_PKGS" ]; then
+    SHA_API_ERROR_PKGS_TRIMMED=$(echo "$SHA_API_ERROR_PKGS" | xargs)
+    echo ""
+    echo "[WARN] formulae.brew.sh unreachable for SHA verification: $SHA_API_ERROR_PKGS_TRIMMED"
+    SHA_IS_INTERACTIVE=false
+    if [ "${MOCK_INTERACTIVE_MODE:-0}" = "1" ] || [ -t 0 ]; then
+        SHA_IS_INTERACTIVE=true
+    fi
+    # Under --yes we never prompt; we warn and continue. Same for non-TTY.
+    if [ "$SHA_IS_INTERACTIVE" = true ] && [ "$AUTO_YES" != true ]; then
+        # echo + read instead of read -rp — see brew-safe-install for rationale.
+        echo "Install anyway? [y/N] "
+        read -r SHA_CONFIRM
+        if [[ ! "$SHA_CONFIRM" =~ ^[yY] ]]; then
+            echo "Cancelled."
+            exit 1
+        fi
+    else
+        echo "[WARN] non-interactive or --yes — continuing without SHA verification for those packages"
+    fi
+fi
+
 # Summary
 echo ""
 echo "Results: $CLEAN_COUNT clean"
 if [ -n "$BLOCKED_PKGS" ]; then
     echo "  Blocked (vulnerable):$BLOCKED_PKGS"
+fi
+if [ -n "$TAMPERED_PKGS" ]; then
+    echo "  Blocked (SHA tampered):$TAMPERED_PKGS"
 fi
 if [ -n "$HELD_PKGS" ]; then
     echo "  Held (too fresh):$HELD_PKGS"
@@ -526,3 +647,9 @@ fi
 
 echo ""
 echo "Done."
+
+# Tampering must surface as a non-zero exit in CI / shell pipelines, even
+# when other clean packages upgraded successfully alongside.
+if [ -n "$TAMPERED_PKGS" ]; then
+    exit 1
+fi

--- a/tests/test_brew_safe_deps.py
+++ b/tests/test_brew_safe_deps.py
@@ -32,6 +32,15 @@ def mock_env(tmp_path, monkeypatch):
     # Ensure no leak from caller's env
     monkeypatch.delenv("BREW_SAFE_NO_DEPS", raising=False)
 
+    # SHA verification became default-on in v0.2.0. Tests in this file don't
+    # mock canonical formulae.brew.sh responses, so point the mock dir at an
+    # empty location — every formula then reads as "tap-only" (no canonical
+    # SHA known), which is a silent-pass outcome and preserves the pre-SHA
+    # behavior these tests were written against.
+    api_dir = tmp_path / "formulae_api_empty"
+    api_dir.mkdir()
+    monkeypatch.setenv("MOCK_FORMULAE_API_DIR", str(api_dir))
+
     return fixture_dir
 
 

--- a/tests/test_brew_safe_sha.py
+++ b/tests/test_brew_safe_sha.py
@@ -1,0 +1,373 @@
+"""
+Tests for SHA verification in brew-safe-install and brew-safe-upgrade.
+
+Contract (drafted 2026-05-14, TDD red phase):
+
+1. Untampered formula: local tap SHA == canonical formulae.brew.sh SHA -> [sha] verified, exit 0.
+2. Tampered formula: local SHA != canonical -> [BLOCKED] SHA mismatch, non-zero exit.
+   No prompt, no --yes override.
+3. No-bottle formula (built from source): canonical has no bottle -> log + exit 0.
+4a. Canonical API returns 404 (tap-only formula): log "tap-only", no prompt, exit 0.
+4b. Canonical API 5xx/timeout, interactive: prompt [WARN] ... Install anyway? [y/N].
+    Default N. User declines -> non-zero exit. User confirms -> exit 0.
+4c. Canonical API 5xx/timeout, batch (--yes OR non-interactive): warn loudly, continue.
+5. Cask + SHA verify: pass-through, log "casks not in scope", exit 0.
+   Brew enforces cask-file SHA on its end.
+6. Symmetry: same contract for brew-safe-install and brew-safe-upgrade.
+7. --no-verify-sha opt-out skips the check entirely. Default is ON.
+
+Test escape hatches the production code must honor:
+- MOCK_FORMULAE_API_DIR: directory of pre-canned canonical responses, used instead
+  of curl https://formulae.brew.sh. File present -> 200 OK with that JSON.
+  File absent -> simulate 404. File contains "__SIMULATE_API_ERROR__" -> 5xx/timeout.
+- MOCK_INTERACTIVE_MODE=1: forces the prompt branch even under subprocess
+  (which has no TTY). Production code never sets this; tests do.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+MOCK_BREW_BIN = Path(__file__).parent / "fixtures" / "mock_brew"
+SAFE_INSTALL = REPO / "brew-safe-install"
+SAFE_UPGRADE = REPO / "brew-safe-upgrade"
+
+CLEAN_SHA = "a" * 64
+TAMPERED_SHA = "b" * 64
+
+
+# ----------------------- fixtures + helpers -----------------------
+
+
+@pytest.fixture
+def sha_env(tmp_path, monkeypatch):
+    """Mock both `brew info` and the formulae.brew.sh canonical API."""
+    brew_dir = tmp_path / "brew_responses"
+    brew_dir.mkdir()
+    api_dir = tmp_path / "formulae_api"
+    api_dir.mkdir()
+
+    monkeypatch.setenv("MOCK_BREW_DIR", str(brew_dir))
+    monkeypatch.setenv("MOCK_FORMULAE_API_DIR", str(api_dir))
+    monkeypatch.setenv("PATH", f"{MOCK_BREW_BIN}:{os.environ['PATH']}")
+    monkeypatch.delenv("BREW_SAFE_NO_DEPS", raising=False)
+
+    # Stub the CVE checker so SHA-verify tests don't hit real APIs.
+    stub = tmp_path / "cve_stub.py"
+    stub.write_text("#!/usr/bin/env python3\nimport sys\nprint('{}')\nsys.exit(0)\n")
+    stub.chmod(0o755)
+    monkeypatch.setenv("DEPENDENCY_SECURITY_CHECK", str(stub))
+
+    return {"brew": brew_dir, "api": api_dir}
+
+
+def write_formula_info(brew_dir: Path, name: str, version: str, sha256: str | None = None):
+    """Mimic `brew info --json=v2 <formula>` with an optional bottle SHA."""
+    formula = {
+        "name": name,
+        "full_name": name,
+        "versions": {"stable": version},
+        "installed": [],
+    }
+    if sha256:
+        formula["bottle"] = {"stable": {"files": {"arm64_sequoia": {"sha256": sha256}}}}
+    payload = {"formulae": [formula], "casks": []}
+    (brew_dir / f"info_{name}.json").write_text(json.dumps(payload))
+
+
+def write_cask_info(brew_dir: Path, name: str, version: str):
+    payload = {
+        "formulae": [],
+        "casks": [{"token": name, "name": [name], "version": version}],
+    }
+    (brew_dir / f"info_{name}.json").write_text(json.dumps(payload))
+
+
+def write_deps(brew_dir: Path, name: str, deps: list[str]):
+    """Mimic `brew deps <name>`."""
+    (brew_dir / f"deps_{name}.txt").write_text("\n".join(deps) + "\n" if deps else "")
+
+
+def write_outdated(brew_dir: Path, formulae: list[dict]):
+    """Mimic `brew outdated --json=v2` — needed for safe-upgrade tests."""
+    (brew_dir / "outdated.json").write_text(json.dumps({"formulae": formulae, "casks": []}))
+
+
+def write_canonical_sha(api_dir: Path, name: str, sha256: str):
+    """Canonical 200 OK response from formulae.brew.sh."""
+    payload = {
+        "name": name,
+        "bottle": {"stable": {"files": {"arm64_sequoia": {"sha256": sha256}}}},
+    }
+    (api_dir / f"{name}.json").write_text(json.dumps(payload))
+
+
+def write_canonical_no_bottle(api_dir: Path, name: str):
+    """Formula exists in canonical API but has no bottle (built from source)."""
+    payload = {"name": name, "bottle": {"stable": {"files": {}}}}
+    (api_dir / f"{name}.json").write_text(json.dumps(payload))
+
+
+def write_canonical_api_error(api_dir: Path, name: str):
+    """Simulate transient 5xx / timeout from the canonical API."""
+    (api_dir / f"{name}.json").write_text("__SIMULATE_API_ERROR__")
+
+
+def outdated_entry(name: str, installed: str, current: str) -> dict:
+    return {
+        "name": name,
+        "installed_versions": [installed],
+        "current_version": current,
+    }
+
+
+def run_safe(
+    script: Path,
+    args: list[str],
+    env_extra: dict | None = None,
+    input_text: str = "n\n",
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(script), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env=env,
+        input=input_text,
+    )
+
+
+# ----------------------- Case 1: untampered passes -----------------------
+
+
+def test_install_untampered_formula_verifies_and_passes(sha_env):
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", CLEAN_SHA)
+    write_canonical_sha(sha_env["api"], "wget", CLEAN_SHA)
+    write_deps(sha_env["brew"], "wget", [])
+
+    result = run_safe(SAFE_INSTALL, ["wget"], input_text="n\n")
+    assert "[sha] verified" in result.stdout, result.stdout
+    assert "[BLOCKED]" not in result.stdout
+    assert "SHA mismatch" not in result.stdout
+
+
+def test_upgrade_untampered_formula_verifies_and_passes(sha_env):
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", CLEAN_SHA)
+    write_canonical_sha(sha_env["api"], "wget", CLEAN_SHA)
+    write_deps(sha_env["brew"], "wget", [])
+    write_outdated(sha_env["brew"], [outdated_entry("wget", "1.24.0", "1.25.0")])
+
+    result = run_safe(SAFE_UPGRADE, ["--yes"], input_text="")
+    assert "[sha] verified" in result.stdout, result.stdout
+    assert "[BLOCKED]" not in result.stdout
+
+
+# ----------------------- Case 2: tampered blocks (no prompt) -----------------------
+
+
+def test_install_tampered_formula_blocks(sha_env):
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", TAMPERED_SHA)
+    write_canonical_sha(sha_env["api"], "wget", CLEAN_SHA)
+    write_deps(sha_env["brew"], "wget", [])
+
+    result = run_safe(SAFE_INSTALL, ["wget"], input_text="n\n")
+    assert "[BLOCKED]" in result.stdout, result.stdout
+    assert "SHA mismatch" in result.stdout
+    # No prompt — tampering is not a user choice.
+    assert "Install anyway?" not in result.stdout
+    assert result.returncode != 0
+
+
+def test_upgrade_tampered_formula_blocks_even_with_yes(sha_env):
+    """--yes never overrides a tampering block."""
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", TAMPERED_SHA)
+    write_canonical_sha(sha_env["api"], "wget", CLEAN_SHA)
+    write_deps(sha_env["brew"], "wget", [])
+    write_outdated(sha_env["brew"], [outdated_entry("wget", "1.24.0", "1.25.0")])
+
+    result = run_safe(SAFE_UPGRADE, ["--yes"], input_text="")
+    assert "[BLOCKED]" in result.stdout, result.stdout
+    assert "SHA mismatch" in result.stdout
+    assert result.returncode != 0
+
+
+# ----------------------- Case 3: no-bottle formula passes -----------------------
+
+
+def test_install_no_bottle_formula_passes(sha_env):
+    write_formula_info(sha_env["brew"], "buildit", "1.0.0", CLEAN_SHA)
+    write_canonical_no_bottle(sha_env["api"], "buildit")
+    write_deps(sha_env["brew"], "buildit", [])
+
+    result = run_safe(SAFE_INSTALL, ["buildit"], input_text="n\n")
+    assert "no bottle" in result.stdout, result.stdout
+    assert "[BLOCKED]" not in result.stdout
+
+
+# ----------------------- Case 4a: 404 tap-only formula -----------------------
+
+
+def test_install_tap_only_formula_passes_with_log(sha_env):
+    write_formula_info(sha_env["brew"], "thirdparty", "0.1.0", CLEAN_SHA)
+    # No canonical fixture written -> simulates 404 from formulae.brew.sh
+    write_deps(sha_env["brew"], "thirdparty", [])
+
+    result = run_safe(SAFE_INSTALL, ["thirdparty"], input_text="n\n")
+    assert "tap-only" in result.stdout, result.stdout
+    assert "[BLOCKED]" not in result.stdout
+    assert "Install anyway?" not in result.stdout
+
+
+# ----------------------- Case 4b: API error + interactive -> prompt -----------------------
+
+
+def test_install_api_error_prompts_in_interactive_user_declines(sha_env):
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", CLEAN_SHA)
+    write_canonical_api_error(sha_env["api"], "wget")
+    write_deps(sha_env["brew"], "wget", [])
+
+    result = run_safe(
+        SAFE_INSTALL,
+        ["wget"],
+        env_extra={"MOCK_INTERACTIVE_MODE": "1"},
+        input_text="n\n",
+    )
+    assert "[WARN]" in result.stdout, result.stdout
+    assert "Install anyway?" in result.stdout
+    assert result.returncode != 0
+
+
+def test_install_api_error_prompts_in_interactive_user_confirms(sha_env):
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", CLEAN_SHA)
+    write_canonical_api_error(sha_env["api"], "wget")
+    write_deps(sha_env["brew"], "wget", [])
+
+    result = run_safe(
+        SAFE_INSTALL,
+        ["wget"],
+        env_extra={"MOCK_INTERACTIVE_MODE": "1"},
+        input_text="y\n",
+    )
+    assert "[WARN]" in result.stdout
+    assert "Install anyway?" in result.stdout
+    assert result.returncode == 0
+
+
+def test_install_api_error_single_prompt_for_batch(sha_env):
+    """Multiple packages with unreachable SHAs collect into ONE prompt, not N."""
+    for name in ("foo", "bar", "baz"):
+        write_formula_info(sha_env["brew"], name, "1.0.0", CLEAN_SHA)
+        write_canonical_api_error(sha_env["api"], name)
+        write_deps(sha_env["brew"], name, [])
+
+    result = run_safe(
+        SAFE_INSTALL,
+        ["foo", "bar", "baz"],
+        env_extra={"MOCK_INTERACTIVE_MODE": "1"},
+        input_text="n\n",
+    )
+    # The prompt should appear exactly once.
+    assert result.stdout.count("Install anyway?") == 1, result.stdout
+
+
+# ----------------------- Case 4c: API error + batch -> warn + continue -----------------------
+
+
+def test_upgrade_api_error_with_yes_warns_and_continues(sha_env):
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", CLEAN_SHA)
+    write_canonical_api_error(sha_env["api"], "wget")
+    write_deps(sha_env["brew"], "wget", [])
+    write_outdated(sha_env["brew"], [outdated_entry("wget", "1.24.0", "1.25.0")])
+
+    result = run_safe(SAFE_UPGRADE, ["--yes"], input_text="")
+    assert "[WARN]" in result.stdout
+    assert "Install anyway?" not in result.stdout  # No prompt under --yes
+    assert result.returncode == 0
+
+
+def test_install_api_error_non_interactive_warns_and_continues(sha_env):
+    """Subprocess context (no TTY, no MOCK_INTERACTIVE_MODE): warn + continue.
+    Must not hang waiting for a prompt that nobody can answer."""
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", CLEAN_SHA)
+    write_canonical_api_error(sha_env["api"], "wget")
+    write_deps(sha_env["brew"], "wget", [])
+
+    result = run_safe(SAFE_INSTALL, ["wget"], input_text="")
+    assert "[WARN]" in result.stdout, result.stdout
+    assert "Install anyway?" not in result.stdout
+    assert result.returncode == 0
+
+
+# ----------------------- Case 5: cask pass-through -----------------------
+
+
+def test_install_cask_skips_sha_check(sha_env):
+    write_cask_info(sha_env["brew"], "firefox", "200.0")
+    write_deps(sha_env["brew"], "firefox", [])
+
+    result = run_safe(SAFE_INSTALL, ["firefox"], input_text="n\n")
+    assert "casks not in scope" in result.stdout, result.stdout
+    assert "[BLOCKED]" not in result.stdout
+    assert "[sha] verified" not in result.stdout
+
+
+# ----------------------- Case 7: --no-verify-sha opt-out -----------------------
+
+
+def test_install_no_verify_sha_skips_check_entirely(sha_env):
+    """When opted out, even a tampered SHA does not block (user took the risk)."""
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", TAMPERED_SHA)
+    write_canonical_sha(sha_env["api"], "wget", CLEAN_SHA)
+    write_deps(sha_env["brew"], "wget", [])
+
+    result = run_safe(SAFE_INSTALL, ["--no-verify-sha", "wget"], input_text="n\n")
+    assert "[sha]" not in result.stdout
+    assert "[BLOCKED]" not in result.stdout
+    assert "SHA mismatch" not in result.stdout
+
+
+def test_upgrade_no_verify_sha_skips_check_entirely(sha_env):
+    write_formula_info(sha_env["brew"], "wget", "1.25.0", TAMPERED_SHA)
+    write_canonical_sha(sha_env["api"], "wget", CLEAN_SHA)
+    write_deps(sha_env["brew"], "wget", [])
+    write_outdated(sha_env["brew"], [outdated_entry("wget", "1.24.0", "1.25.0")])
+
+    result = run_safe(SAFE_UPGRADE, ["--no-verify-sha", "--yes"], input_text="")
+    assert "[sha]" not in result.stdout
+    assert "[BLOCKED]" not in result.stdout
+
+
+# ----------------------- Default-on and help-text assertions -----------------------
+
+
+def test_install_verify_sha_default_is_true():
+    """Source-level assertion: the initialization line must be VERIFY_SHA=true.
+    Not the flag handler — that's a separate line that begins with `--verify-sha)`."""
+    text = SAFE_INSTALL.read_text()
+    assert re.search(r"^VERIFY_SHA=true\b", text, re.MULTILINE), (
+        "Default must be ON after this PR (init line must read `VERIFY_SHA=true`)"
+    )
+
+
+def test_upgrade_verify_sha_default_is_true():
+    text = SAFE_UPGRADE.read_text()
+    assert re.search(r"^VERIFY_SHA=true\b", text, re.MULTILINE)
+
+
+def test_install_help_documents_no_verify_sha_flag():
+    """Help output must advertise the opt-out, not opt-in."""
+    text = SAFE_INSTALL.read_text()
+    assert "--no-verify-sha" in text
+
+
+def test_upgrade_help_documents_no_verify_sha_flag():
+    text = SAFE_UPGRADE.read_text()
+    assert "--no-verify-sha" in text

--- a/tests/test_brew_safe_sha.py
+++ b/tests/test_brew_safe_sha.py
@@ -26,6 +26,7 @@ Test escape hatches the production code must honor:
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -210,6 +211,20 @@ def test_install_no_bottle_formula_passes(sha_env):
     result = run_safe(SAFE_INSTALL, ["buildit"], input_text="n\n")
     assert "no bottle" in result.stdout, result.stdout
     assert "[BLOCKED]" not in result.stdout
+
+
+def test_install_no_local_bottle_is_not_tampering(sha_env):
+    """Symmetric case: local has no bottle (built --from-source), canonical does.
+    Must NOT be classified as tampering."""
+    # Note: write_formula_info(... sha256=None) omits the bottle entry from local.
+    write_formula_info(sha_env["brew"], "src_only", "1.0.0", sha256=None)
+    write_canonical_sha(sha_env["api"], "src_only", CLEAN_SHA)
+    write_deps(sha_env["brew"], "src_only", [])
+
+    result = run_safe(SAFE_INSTALL, ["src_only"], input_text="n\n")
+    assert "[BLOCKED]" not in result.stdout, result.stdout
+    assert "SHA mismatch" not in result.stdout
+    assert "no local bottle" in result.stdout
 
 
 # ----------------------- Case 4a: 404 tap-only formula -----------------------


### PR DESCRIPTION
## Summary
Bottle SHA verification flips from opt-in (`--verify-sha`) to **default-on** for both `brew-safe-install` and `brew-safe-upgrade`. The local-tap bottle SHA from `brew info --json=v2` is now compared against the canonical SHA published at `formulae.brew.sh` on every install/upgrade.

## Five outcomes

| Outcome | Output | Behaviour |
|---|---|---|
| **Match** | `[sha] verified <local>=<canonical>` | continue |
| **Mismatch** | `[BLOCKED] SHA mismatch` + both full fingerprints | package excluded, script exits non-zero; **`--yes` never overrides this** |
| **No bottle** | `[sha] no bottle — built from source` | continue (covers both: canonical has no bottle OR local tap has no bottle) |
| **Tap-only / 404** | `[sha] tap-only formula — no canonical SHA available` | continue, no prompt |
| **API 5xx / timeout** | end-of-loop `[WARN] formulae.brew.sh unreachable... Install anyway? [y/N]` | interactive: prompt once for all; non-TTY or `--yes`: warn + continue |

Casks are out of scope — brew enforces the cask-file SHA on every install, so duplicating here adds no signal.

## Backward compatibility
- `--no-verify-sha` opts out entirely (default is ON)
- The previous `--verify-sha` flag is accepted as a silent no-op
- The pre-existing `mock_env` fixture in `test_brew_safe_deps.py` now sets `MOCK_FORMULAE_API_DIR` to an empty dir so its 21 tests still pass (every formula reads as "tap-only", silent-pass)

## Test escape hatches (production never sets these)
- `MOCK_FORMULAE_API_DIR` — read canonical JSON from filesystem instead of curl
- `MOCK_INTERACTIVE_MODE=1` — force prompt branch under subprocess (no TTY)

## Code review findings (addressed before commit)
1. **Source-built false positive** — empty local SHA vs real canonical SHA would have been classified as tampering. Fixed with an explicit `[ -z "$LOCAL_SHA" ]` guard that routes to the `no_bottle` verdict before the comparison. Locked in by a new regression test `test_install_no_local_bottle_is_not_tampering`.

## Test plan
- [x] All 19 SHA contract tests pass
- [x] All 21 pre-existing tests still pass (40 total)
- [x] Symmetry: identical contract in both `brew-safe-install` and `brew-safe-upgrade`
- [x] No new bash 3.2 incompatibility
- [x] No shell injection vector (URLs constructed from `$BARE_NAME` / `$name` are double-quoted; malformed names hit 404 → api_error path)
- [ ] After merge: run `brew safe-install <formula>` against a real installation and confirm `[sha] verified` line appears

## CHANGELOG + README
Both updated to document the new contract, opt-out flag, and the prompt UX.