### PR TITLE
feat: add GitHub Sponsors setup

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding model for this project. See:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: sharkyger

--- a/.github/workflows/sponsors-readme.yml
+++ b/.github/workflows/sponsors-readme.yml
@@ -1,0 +1,23 @@
+name: Update sponsors in README
+
+on:
+  schedule:
+    - cron: '0 6 * * *'          # daily 06:00 UTC (08:00 CEST)
+  workflow_dispatch:               # allow manual trigger
+
+permissions:
+  contents: write                  # action commits the regenerated README
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Render sponsors
+        uses: JamesIves/github-sponsors-readme-action@2fd9142e765f755780202122261dc85e78459405  # v1.6.0
+        with:
+          token: ${{ secrets.SPONSORS_PAT }}
+          file: 'README.md'
+          fallback: 'No sponsors yet — [become the first](https://github.com/sponsors/sharkyger).'

--- a/README.md
+++ b/README.md
@@ -385,6 +385,15 @@ And of course:
 
 These organizations and communities make it possible for anyone to build security tooling without paywalls or API key barriers. Thank you.
 
+## Sponsors
+
+This tool stays free and default-on thanks to the people and companies funding the maintenance time.
+
+<!-- sponsors -->
+<!-- sponsors -->
+
+[**Become a sponsor →**](https://github.com/sponsors/sharkyger)
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Add \`.github/FUNDING.yml\` so the repo's Sponsor button appears
- Add scheduled GitHub Action (\`JamesIves/github-sponsors-readme-action\`, pinned to commit SHA) that regenerates the Sponsors list in README daily at 06:00 UTC, plus \`workflow_dispatch\` for manual runs
- Add \`## Sponsors\` section to README between Acknowledgments and License, with the action's marker comments

Both \`actions/checkout\` and \`github-sponsors-readme-action\` pinned to commit SHA (supply-chain hygiene). Workflow needs the \`SPONSORS_PAT\` repo secret (classic PAT with \`read:user\` + \`read:org\`). Until that secret is set, the action renders the fallback text in place of sponsor avatars.

## Test plan

- [ ] After merge, set \`SPONSORS_PAT\` secret in repo settings
- [ ] Trigger workflow manually: \`gh workflow run "Update sponsors in README"\`
- [ ] Expect green run + fallback text injected between \`<!-- sponsors -->\` markers on \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)