### PR TITLE
fix(workflow): add commit step so sponsors README updates persist

### DIFF
--- a/.github/workflows/sponsors-readme.yml
+++ b/.github/workflows/sponsors-readme.yml
@@ -21,3 +21,9 @@ jobs:
           token: ${{ secrets.SPONSORS_PAT }}
           file: 'README.md'
           fallback: 'No sponsors yet — [become the first](https://github.com/sponsors/sharkyger).'
+
+      - name: Commit + push README updates
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
+        with:
+          commit_message: 'chore: update sponsors in README'
+          file_pattern: 'README.md'


### PR DESCRIPTION
## Summary

The \`JamesIves/github-sponsors-readme-action\` only modifies \`README.md\` in the runner's workspace — it does **not** commit the change back to the repo. The first sponsors workflow run completed green and reported "Found 0 matching sponsors", but the \`<!-- sponsors -->\` block on \`main\` was never updated because there was no commit/push step.

Adding \`stefanzweifel/git-auto-commit-action\` (pinned to commit SHA \`04702edda442b2e678b25b537cec683a1493fcb9\` for v7.1.0) after the render step. It uses the workflow's existing \`contents: write\` permission and the default \`GITHUB_TOKEN\`, commits as \`github-actions[bot]\` with message \`chore: update sponsors in README\`, and pushes only if \`README.md\` actually changed.

\`GITHUB_TOKEN\` commits don't trigger downstream workflows (GitHub safety net), so this won't create CI loops.

## Test plan

- [ ] After merge, trigger workflow manually: \`gh workflow run "Update sponsors in README"\`
- [ ] Expect the action to render the sponsor block (fallback text while 0 sponsors) AND a follow-up \`chore: update sponsors in README\` commit on \`main\` from \`github-actions[bot]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)