### PR TITLE
fix(workflow): use peter-evans/create-pull-request for protected main

### DIFF
--- a/.github/workflows/sponsors-readme.yml
+++ b/.github/workflows/sponsors-readme.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:               # allow manual trigger
 
 permissions:
-  contents: write                  # action commits the regenerated README
+  contents: write                  # commit on a side branch
+  pull-requests: write             # open the PR
 
 jobs:
   update:
@@ -22,8 +23,18 @@ jobs:
           file: 'README.md'
           fallback: 'No sponsors yet — [become the first](https://github.com/sponsors/sharkyger).'
 
-      - name: Commit + push README updates
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
+      - name: Open PR for README updates
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
-          commit_message: 'chore: update sponsors in README'
-          file_pattern: 'README.md'
+          sign-commits: true             # GraphQL createCommitOnBranch → web-flow verified
+          commit-message: 'chore: update sponsors in README'
+          title: 'chore: update sponsors in README'
+          body: |
+            Auto-generated update to the Sponsors section by [`JamesIves/github-sponsors-readme-action`](https://github.com/JamesIves/github-sponsors-readme-action).
+
+            Merging this PR refreshes the sponsor logos and names rendered between the `<!-- sponsors -->` markers in `README.md`.
+
+            Triggered by the daily `Update sponsors in README` workflow run.
+          branch: chore/sponsors-readme-update
+          delete-branch: true
+          add-paths: README.md


### PR DESCRIPTION
## Summary

Previous fix (PR #36) used \`stefanzweifel/git-auto-commit-action\` to push the regenerated README directly to \`main\`. That run failed because branch protection on \`main\` requires:
- Changes via PR (no direct push)
- Signed commits (bot can't sign without a key)
- 5 required status checks (this repo only)

Switching to \`peter-evans/create-pull-request\` (pinned to commit SHA \`5f6978faf089d4d20b00c7766989d076bb2fc7f1\` for v8.1.1). The workflow now opens a PR on a side branch (\`chore/sponsors-readme-update\`) whenever the sponsor list changes. Maintainer merges with \`--admin\` (same flow as the rest of this infra).

\`sign-commits: true\` switches the action to GitHub's GraphQL \`createCommitOnBranch\` mutation, which produces web-flow-signed commits — satisfies the verified-signatures rule.

\`pull-requests: write\` added to permissions (needed to open the PR).

## Steady-state behavior

At realistic sponsor counts (0–3 expected for several months), the rendered README content rarely changes — so this PR fires near-zero in steady state. Only signs of life: a sponsor signs up, cancels, or changes their public name.

## Test plan

- [ ] After merge, trigger workflow manually: \`gh workflow run "Update sponsors in README"\`
- [ ] Expect: green workflow run, no immediate change (0 sponsors), and either a PR opens with the fallback text OR the action no-ops cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)