### PR TITLE
chore: gitignore local code-review artifacts (.codereview/) + *.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ __pycache__/
 .pytest_cache/
 *.egg-info/
 dist/
+
+# Local code-review artifacts (Mistral Vibe / CodeRabbit / subagent) — never commit
+.codereview/
+# Local-only working notes / security handoffs — never commit
+*.local.md


### PR DESCRIPTION
Ignore local-only review artifacts so they never leak into the public repo:

- `.codereview/` — local AI/Mistral/CodeRabbit/subagent review reports (findings/ + reports/)
- `*.local.md` — local-only working notes / security handoffs

Tooling/hygiene only; no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore rules to exclude local code-review artifacts and private working notes.

---

Note: This release contains no user-facing changes. Updates are internal maintenance only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->