### PR TITLE
docs: use persona name on LICENSE copyright line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Thorsten Beck
+Copyright (c) 2026 Sharky
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What

Handoff Task 2 (content sweep). The LICENSE copyright line carried the real maintainer name behind the `sharkyger` persona — the one maintainer-personal reference still shipping in a tracked file. Reworded to the persona name `Sharky`.

## Scope

- Current files only; git history is unchanged (accept-past-exposure decision).
- Full re-sweep confirms **no** `thorsten` / `thors10beck` / `augatho` / `beck-webdesign` / fingerprint-email strings remain in any tracked file.
- Everything else already used the persona correctly (`pyproject.toml` author, `@sharkyger`, all GitHub URLs).

One line changed:

```
-Copyright (c) 2026 Thorsten Beck
+Copyright (c) 2026 Sharky
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright attribution in the license file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->