### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The project is pre-1.0; expect minor breaking changes between 0.x releases until
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-06-03
+
 ### Fixed
 - **`brew safe-update` is now self-healing — single-run convergence (fixes the second Intel-Mac error).** While verifying the bottle-SHA fix on a real Intel (x86_64) Mac, two distinct errors surfaced in sequence:
   1. `[BLOCKED] SHA mismatch` on **every** bottle — the architecture bug (see the arch-aware entry below). This is the one the bottle-SHA fix addresses.
@@ -111,4 +113,6 @@ pre-tag history by theme rather than by release. Full detail is in `git log`.
 - CodeQL, gitleaks, and dependabot wired up.
 - Community health files: issue templates (bug, false-positive, feature), discussion link from README on the open `--min-age` default question.
 
-[Unreleased]: https://github.com/sharkyger/homebrew-safe-upgrade/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/sharkyger/homebrew-safe-upgrade/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/sharkyger/homebrew-safe-upgrade/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/sharkyger/homebrew-safe-upgrade/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ This places all files in your Homebrew bin directory (`/opt/homebrew/bin/` on Ap
 ```bash
 git clone https://github.com/sharkyger/homebrew-safe-upgrade.git
 cd homebrew-safe-upgrade
-cp brew-safe-upgrade brew-safe-install brew-safe-update dependency_security_check.py /opt/homebrew/bin/
+cp brew-safe-upgrade brew-safe-install brew-safe-update dependency_security_check.py bottle_resolver.py cask_nvd_map.py /opt/homebrew/bin/
 chmod +x /opt/homebrew/bin/brew-safe-upgrade /opt/homebrew/bin/brew-safe-install /opt/homebrew/bin/brew-safe-update
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "homebrew-safe-upgrade"
-version = "0.1.0"
+version = "0.2.0"
 description = "Security-first brew upgrade — checks packages against NIST NVD, OSV.dev, and GitHub Advisory before upgrading"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## v0.2.0 release prep

Cuts **v0.2.0**. This PR is docs/metadata only — all the behavior changes already merged (#45/#46/#47 bottle-SHA chain, #48 LICENSE persona fix, plus the earlier SHA-default-on / min-age / cask-map work).

- `pyproject.toml`: `0.1.0` → `0.2.0` (was stale; never bumped for v0.1.1).
- `CHANGELOG.md`: `[Unreleased]` → `[0.2.0] — 2026-06-03`; fixed the compare-link refs (`[Unreleased]` now `v0.2.0...HEAD`, added `[0.2.0]` and `[0.1.1]`).
- `README.md`: corrected the **stale manual-install list** — it was missing `bottle_resolver.py` + `cask_nvd_map.py`, so a manual install would ship an incomplete runtime set and fail closed (same drift class #46 fixed for `install.sh` / `brew-safe-update`).

### Headline changes since v0.1.1
SHA verification default-on · `--min-age` 3-day default · curated cask→NVD map · **arch-aware bottle-SHA resolver** (Intel x86_64 false-positive fix) · **self-healing `brew-safe-update`**.

### Validation
Linuxbrew **x86_64 container dogfood** (honoring never-test-on-host): install lands all 6 files → `brew safe-update` self-heals → x86_64 host resolves `x86_64_linux` (not arm64) → fail-closed guard fires when the resolver is removed → `brew safe-install hello` = `[sha] verified`. shellcheck + ruff (check & format) clean, **98 tests pass**.

### Not in this PR (deliberate)
No `brew install sharkyger/tap/...` docs yet — the tap formula doesn't exist until the `homebrew-tap` session ships `safe-upgrade.rb` (which is BLOCKED until this v0.2.0 tag/release lands). Making the tap-distribution claim accurate is a separate, gated follow-up.

### After merge
Signed tag `v0.2.0` → GitHub release → this unblocks the `homebrew-tap` session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to include additional helper scripts.
  * Added release notes for version 0.2.0.

* **Chores**
  * Bumped project version to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->