### PR TITLE
docs: cross-platform manual-install path (re-land, missed in #49 merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,9 @@ This places all files in your Homebrew bin directory (`/opt/homebrew/bin/` on Ap
 ```bash
 git clone https://github.com/sharkyger/homebrew-safe-upgrade.git
 cd homebrew-safe-upgrade
-cp brew-safe-upgrade brew-safe-install brew-safe-update dependency_security_check.py bottle_resolver.py cask_nvd_map.py /opt/homebrew/bin/
-chmod +x /opt/homebrew/bin/brew-safe-upgrade /opt/homebrew/bin/brew-safe-install /opt/homebrew/bin/brew-safe-update
+BIN="$(brew --prefix)/bin"   # /opt/homebrew/bin on Apple Silicon, /usr/local/bin on Intel
+cp brew-safe-upgrade brew-safe-install brew-safe-update dependency_security_check.py bottle_resolver.py cask_nvd_map.py "$BIN/"
+chmod +x "$BIN"/brew-safe-upgrade "$BIN"/brew-safe-install "$BIN"/brew-safe-update
 ```
 
 ### Verify


### PR DESCRIPTION
The \$(brew --prefix)/bin fix for the manual-install snippet (CodeRabbit on #49) did not make it into the #49 squash-merge — a push race left the PR head at the prior commit. Re-landing it here so v0.2.0 ships with it.

Manual-install now resolves the brew prefix at runtime, correct on both Apple Silicon (/opt/homebrew) and Intel (/usr/local) — the same arch/path split this whole release is about.

Must merge BEFORE the v0.2.0 tag so the release includes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated manual installation instructions to dynamically detect Homebrew's installation directory instead of using hardcoded paths, ensuring compatibility across different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->