### PR TITLE
docs: document the Homebrew tap install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The project is pre-1.0; expect minor breaking changes between 0.x releases until
 
 ## [Unreleased]
 
+### Added
+- **Homebrew tap install** — `brew install sharkyger/tap/safe-upgrade` now works (formula lives in [`sharkyger/homebrew-tap`](https://github.com/sharkyger/homebrew-tap)). It installs all three commands plus the runtime modules (`bottle_resolver.py`, `cask_nvd_map.py`) and pulls in `python@3.12`. Tap installs update through brew — `brew update && brew upgrade safe-upgrade` — **not** the bundled `brew safe-update`, which only refreshes a script install in your Homebrew `bin`. README install docs updated to lead with the tap path and document this distinction.
+
 ## [0.2.0] — 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Packages that are already installed are detected and skipped.
 
 ## brew safe-update
 
-Updates all tools to the latest version from GitHub.
+Updates all tools to the latest version from GitHub. This is for the **script / manual** install — it refreshes the copies in your Homebrew `bin`.
 
 ```
 brew safe-update
@@ -273,6 +273,8 @@ No need to re-run the install script. If you get a permission error:
 ```
 sudo brew safe-update
 ```
+
+> **Installed via the tap?** Don't use `brew safe-update` — update through brew instead: `brew update && brew upgrade safe-upgrade`. `brew safe-update` only refreshes a script install in `bin`; it doesn't touch the formula in the Homebrew cellar.
 
 ## Standalone security checker
 
@@ -311,7 +313,23 @@ JSON output on stdout for programmatic use:
 
 ## Install
 
-### Quick install (Homebrew prefix)
+### Homebrew tap (recommended)
+
+```bash
+brew install sharkyger/tap/safe-upgrade
+```
+
+This taps `sharkyger/tap` automatically and installs `brew safe-upgrade`, `brew safe-install`, and `brew safe-update`, along with the Python modules they need (`depends_on python@3.12`).
+
+**Updating a tap install:** update through brew like any other formula —
+
+```bash
+brew update && brew upgrade safe-upgrade
+```
+
+Don't use `brew safe-update` for a tap install — that refreshes the script-install copy in your Homebrew `bin`, not the formula in the cellar.
+
+### Script install (no tap)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sharkyger/homebrew-safe-upgrade/main/install.sh | bash


### PR DESCRIPTION
## Make the Homebrew-tap install path accurate

`safe-upgrade.rb` is now merged + published in [`sharkyger/homebrew-tap`](https://github.com/sharkyger/homebrew-tap), so `brew install sharkyger/tap/safe-upgrade` works. This was previously undocumented (README only showed the `install.sh` script path). Docs-only.

### README
- New **Homebrew tap (recommended)** install subsection leading the Install section.
- Relabeled the script path as **Script install (no tap)**.
- **Key nuance documented** (both in the install section and the `brew safe-update` section): tap installs update via `brew update && brew upgrade safe-upgrade`, **not** the bundled `brew safe-update` — that command only refreshes a *script* install in your Homebrew `bin`, not the formula in the cellar.

### CHANGELOG
- `[Unreleased]` → **Added**: the tap install path + the update-method distinction.

### Not in this PR
The project `CLAUDE.md` (untracked — holds internal fleet rules) was also updated locally for agent-context accuracy (License `TBD` → MIT; distribution line marked live). It is intentionally **not** committed (it isn't tracked and must not be public).

Pairs with the v0.2.0 release + the tap formula. CHANGELOG + README ship together per the docs-with-code rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation documentation, with Homebrew tap designated as the recommended installation method
  * Added clarification on updating tap-installed versions using `brew update && brew upgrade`
  * Provided guidance distinguishing update procedures for tap installations from alternative installation methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->