### PR TITLE
docs: version-agnostic Python wording in tap install

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ JSON output on stdout for programmatic use:
 brew install sharkyger/tap/safe-upgrade
 ```
 
-This taps `sharkyger/tap` automatically and installs `brew safe-upgrade`, `brew safe-install`, and `brew safe-update`, along with the Python modules they need (`depends_on python@3.12`).
+This taps `sharkyger/tap` automatically and installs `brew safe-upgrade`, `brew safe-install`, and `brew safe-update`. The tools need Python 3.11+ (stdlib only); Homebrew pulls in a managed Python as a dependency (currently `python@3.12`).
 
 **Updating a tap install:** update through brew like any other formula —
 


### PR DESCRIPTION
Addresses CodeRabbit on #51 (README:322). The tap-install line hardcoded \`depends_on python@3.12\`, pinning a detail owned by the tap formula. Reworded to tie to the project baseline (\`requires-python = >=3.11\`) and mark the exact formula as *current*, so this README does not drift when the tap bumps Python.

```
- ... along with the Python modules they need (\`depends_on python@3.12\`).
+ ... The tools need Python 3.11+ (stdlib only); Homebrew pulls in a managed Python as a dependency (currently \`python@3.12\`).
```

One-line README wording fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Homebrew tap installation details, including automatic installation of safe-upgrade, safe-install, and safe-update commands
  * Updated Python version requirement to 3.11+ (stdlib only)
  * Specified Homebrew's managed Python dependency as python@3.12

<!-- end of auto-generated comment: release notes by coderabbit.ai -->