### PR TITLE
fix(scanner): pre-release-aware version comparison (HIGH bypass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,15 @@ The project is pre-1.0; expect minor breaking changes between 0.x releases until
 
 ## [Unreleased]
 
+### Security
+- **Pre-release-aware version comparison — fixes a HIGH scanner bypass.** The CVE range matcher's `parse_version` used a tuple regex that silently dropped pre-release suffixes (`1.0-beta` → `(1, 0)`, equal to `1.0`), so a vulnerable pre-release sorted *equal to* its release and was judged **not affected** against a "fixed in X" advisory range — letting an install/upgrade proceed on a vulnerable pre-release. A second bug made a bare `= X` constraint always read "not affected": an unparenthesized `or op == "="` that, with Python's `and`-binds-tighter-than-`or`, ignored the version entirely. Both are fixed — a small, well-tested stdlib pre-release-aware comparator (`dev < alpha < beta < rc < final`, with trailing-zero equivalence) replaces the tuple parser, and the operator check is parenthesized as `((op == "=" or op == "==") and v != ref)`. Every comparison site is None-safe and unparseable versions/constraints now **fail closed** (treated as affected). The tool stays dependency-free — no `packaging` runtime dependency (Homebrew's Python is externally-managed and lacks it, which would fail-close the whole tool). Locked down by `tests/test_version_validation.py`.
+
+### Fixed
+- The `test_installed_old_version_is_treated_as_incoming` test no longer reads the live Homebrew openssl@3 release date (it now runs with `--min-age 0`), so it stops failing for ~3 days after every openssl@3 bump.
+
 ### Added
 - **Homebrew tap install** — `brew install sharkyger/tap/safe-upgrade` now works (formula lives in [`sharkyger/homebrew-tap`](https://github.com/sharkyger/homebrew-tap)). It installs all three commands plus the runtime modules (`bottle_resolver.py`, `cask_nvd_map.py`) and pulls in `python@3.12`. Tap installs update through brew — `brew update && brew upgrade safe-upgrade` — **not** the bundled `brew safe-update`, which only refreshes a script install in your Homebrew `bin`. README install docs updated to lead with the tap path and document this distinction.
+- Product requirements doc (`docs/PRD.md`).
 
 ## [0.2.0] — 2026-06-03
 

--- a/dependency_security_check.py
+++ b/dependency_security_check.py
@@ -94,20 +94,115 @@ def resolve_latest_version(package_name, ecosystem):
     return None
 
 
+# Pre-release-aware version comparison (a focused PEP 440 subset, stdlib only).
+# This tool ships as bash + stdlib Python with no pip-installed dependencies and
+# no virtualenv, so we carry just enough version logic to compare correctly for
+# CVE range matching rather than take a runtime dependency on `packaging`
+# (Homebrew's python is externally-managed and lacks it, which would fail-close
+# the whole tool). Behaviour is pinned by tests/test_version_validation.py.
+#
+# Handles: dotted numeric releases with trailing-zero equivalence (1.0 == 1.0.0),
+# and pre-release suffixes that sort BELOW their release and among themselves
+# (dev < alpha < beta < rc < final), e.g. 1.0-beta < 1.0, 1.0a1 < 1.0b1 < 1.0rc1.
+# Homebrew revisions (3.5.0_1) and build metadata (+meta) are ignored for order.
+# This replaces an earlier tuple parser that DROPPED pre-release suffixes, so a
+# vulnerable pre-release sorted == its release and was wrongly judged
+# not-affected against a "fixed in X" range (HIGH bypass).
+_PRE_RANK = {
+    "dev": 0,
+    "alpha": 1,
+    "a": 1,
+    "beta": 2,
+    "b": 2,
+    "pre": 3,
+    "preview": 3,
+    "rc": 3,
+    "c": 3,
+}
+_FINAL_RANK = 99  # a final release outranks every pre-release of the same number
+
+
+class _Version:
+    """A comparable version key. Build only via parse_version() (which returns
+    None on unparseable input — callers fail closed on None)."""
+
+    __slots__ = ("_key",)
+
+    def __init__(self, release, pre):
+        # pre is (rank, num) for a pre-release, or None for a final release.
+        self._key = (release, pre if pre is not None else (_FINAL_RANK, 0))
+
+    def __eq__(self, other):
+        return isinstance(other, _Version) and self._key == other._key
+
+    def __lt__(self, other):
+        return self._key < other._key
+
+    def __le__(self, other):
+        return self._key <= other._key
+
+    def __gt__(self, other):
+        return self._key > other._key
+
+    def __ge__(self, other):
+        return self._key >= other._key
+
+    def __hash__(self):
+        return hash(self._key)
+
+
 def parse_version(v):
-    """Parse a version string into a tuple for comparison."""
+    """Parse a version string into a comparable _Version, or None if unparseable.
+
+    Pre-release-aware (1.0-beta < 1.0); returns None on empty/garbage so callers
+    can fail closed. Use the _ver_lt / _ver_le / _ver_gt / _ver_ge helpers for
+    None-safe relational comparisons (a bare `_Version < None` would raise).
+    """
     if not v:
-        return ()
-    # Strip leading 'v' or '=' prefixes
-    v = re.sub(r"^[v=]+", "", v.strip())
-    parts = []
-    for p in v.split("."):
-        m = re.match(r"(\d+)", p)
-        if m:
-            parts.append(int(m.group(1)))
-        else:
-            parts.append(0)
-    return tuple(parts)
+        return None
+    s = re.sub(r"^[v=]+", "", str(v).strip())
+    # Drop Homebrew revision (_N) and build metadata (+meta) before parsing.
+    s = s.split("+", 1)[0].split("_", 1)[0]
+    m = re.match(r"^(\d+(?:\.\d+)*)(.*)$", s)
+    if not m:
+        return None
+    release = tuple(int(x) for x in m.group(1).split("."))
+    # Trailing-zero equivalence: 1.0 == 1.0.0 == 1.
+    while len(release) > 1 and release[-1] == 0:
+        release = release[:-1]
+    pre = None
+    pm = re.match(
+        r"[-_.]?(dev|alpha|beta|preview|pre|rc|a|b|c)[-_.]?(\d*)",
+        m.group(2),
+        re.IGNORECASE,
+    )
+    if pm:
+        pre = (_PRE_RANK[pm.group(1).lower()], int(pm.group(2)) if pm.group(2) else 0)
+    return _Version(release, pre)
+
+
+def _ver_lt(a, b):
+    """parse_version(a) < parse_version(b); False (fail-closed) if either is unparseable."""
+    va, vb = parse_version(a), parse_version(b)
+    return va is not None and vb is not None and va < vb
+
+
+def _ver_le(a, b):
+    """parse_version(a) <= parse_version(b); False if either is unparseable."""
+    va, vb = parse_version(a), parse_version(b)
+    return va is not None and vb is not None and va <= vb
+
+
+def _ver_gt(a, b):
+    """parse_version(a) > parse_version(b); False if either is unparseable."""
+    va, vb = parse_version(a), parse_version(b)
+    return va is not None and vb is not None and va > vb
+
+
+def _ver_ge(a, b):
+    """parse_version(a) >= parse_version(b); False if either is unparseable."""
+    va, vb = parse_version(a), parse_version(b)
+    return va is not None and vb is not None and va >= vb
 
 
 def version_in_range(version, range_str):
@@ -130,7 +225,10 @@ def version_in_range(version, range_str):
         if not cond:
             continue
 
-        m = re.match(r"([<>=!]+)\s*([\d][\d.]*\w*)", cond)
+        # Ref may carry a pre-release suffix (incl. hyphenated, e.g. "1.0-beta"):
+        # capture word chars, dots, plus and hyphen so parse_version sees the
+        # full pre-release — otherwise "= 1.0-beta" would truncate to "1.0".
+        m = re.match(r"([<>=!]+)\s*([\d][\w.+-]*)", cond)
         if not m:
             if parse_version(cond) == v:
                 return True
@@ -138,21 +236,18 @@ def version_in_range(version, range_str):
 
         op, ref_str = m.group(1), m.group(2)
         ref = parse_version(ref_str)
+        # Fail-closed: an unparseable constraint reference means we can't
+        # disprove vulnerability, so treat the version as affected.
+        if ref is None:
+            return True
 
         if (
-            op == "<"
-            and not (v < ref)
-            or op == "<="
-            and not (v <= ref)
-            or op == ">"
-            and not (v > ref)
-            or op == ">="
-            and not (v >= ref)
-            or op == "="
-            or op == "=="
-            and v != ref
-            or op == "!="
-            and v == ref
+            (op == "<" and not (v < ref))
+            or (op == "<=" and not (v <= ref))
+            or (op == ">" and not (v > ref))
+            or (op == ">=" and not (v >= ref))
+            or ((op == "=" or op == "==") and v != ref)
+            or (op == "!=" and v == ref)
         ):
             return False
 
@@ -251,7 +346,7 @@ def query_github(package_name, ecosystem, version=None):
                     else:
                         patched_ver = None
 
-                    if patched_ver and parse_version(version) >= parse_version(patched_ver):
+                    if patched_ver and _ver_ge(version, patched_ver):
                         not_affected = True
                         break
 
@@ -443,21 +538,13 @@ def query_nvd(package_name, ecosystem, version=None):
                             if ver_end_exc or ver_end_inc or ver_start_inc or ver_start_exc:
                                 # Range-based CPE — check if our version falls within
                                 in_range = True
-                                if ver_start_inc and parse_version(version) < parse_version(
-                                    ver_start_inc
-                                ):
+                                if ver_start_inc and _ver_lt(version, ver_start_inc):
                                     in_range = False
-                                if ver_start_exc and parse_version(version) <= parse_version(
-                                    ver_start_exc
-                                ):
+                                if ver_start_exc and _ver_le(version, ver_start_exc):
                                     in_range = False
-                                if ver_end_exc and parse_version(version) >= parse_version(
-                                    ver_end_exc
-                                ):
+                                if ver_end_exc and _ver_ge(version, ver_end_exc):
                                     in_range = False
-                                if ver_end_inc and parse_version(version) > parse_version(
-                                    ver_end_inc
-                                ):
+                                if ver_end_inc and _ver_gt(version, ver_end_inc):
                                     in_range = False
                                 if in_range:
                                     affected = True
@@ -494,17 +581,13 @@ def query_nvd(package_name, ecosystem, version=None):
                         desc,
                         re.IGNORECASE,
                     )
-                    if end_exc:
-                        upper = parse_version(end_exc.group(1))
-                        if upper and parse_version(version) >= upper:
-                            continue  # version is at or above the fix — not affected
+                    if end_exc and _ver_ge(version, end_exc.group(1)):
+                        continue  # version is at or above the fix — not affected
 
                     # Inclusive upper bound: last affected version
                     end_inc = re.search(rf"\bthrough\s+{v_re}", desc, re.IGNORECASE)
-                    if end_inc:
-                        upper = parse_version(end_inc.group(1))
-                        if upper and parse_version(version) > upper:
-                            continue
+                    if end_inc and _ver_gt(version, end_inc.group(1)):
+                        continue
 
                     # Lower bound: affected starts at this version
                     start_inc = re.search(
@@ -512,10 +595,8 @@ def query_nvd(package_name, ecosystem, version=None):
                         desc,
                         re.IGNORECASE,
                     )
-                    if start_inc:
-                        lower = parse_version(start_inc.group(1))
-                        if lower and parse_version(version) < lower:
-                            continue
+                    if start_inc and _ver_lt(version, start_inc.group(1)):
+                        continue
 
             findings.append(
                 {

--- a/dependency_security_check.py
+++ b/dependency_security_check.py
@@ -171,13 +171,24 @@ def parse_version(v):
     while len(release) > 1 and release[-1] == 0:
         release = release[:-1]
     pre = None
-    pm = re.match(
-        r"[-_.]?(dev|alpha|beta|preview|pre|rc|a|b|c)[-_.]?(\d*)",
-        m.group(2),
-        re.IGNORECASE,
-    )
-    if pm:
-        pre = (_PRE_RANK[pm.group(1).lower()], int(pm.group(2)) if pm.group(2) else 0)
+    tail = m.group(2)
+    if tail:
+        pm = re.match(
+            r"[-_.]?(dev|alpha|beta|preview|pre|rc|a|b|c)[-_.]?(\d*)",
+            tail,
+            re.IGNORECASE,
+        )
+        if pm:
+            pre = (_PRE_RANK[pm.group(1).lower()], int(pm.group(2)) if pm.group(2) else 0)
+        elif not re.match(r"^[-_.]?\d", tail):
+            # A non-numeric, unrecognized suffix (e.g. "-SNAPSHOT", "-milestone",
+            # "1.0foo", "1.0.post1", a trailing "1.0.") may be a pre-release
+            # spelling we don't model. Fail closed (return None -> treated as
+            # affected) rather than coerce it to a FINAL release and risk
+            # *under*-flagging a vulnerable pre-release. A trailing NUMERIC patch
+            # (Homebrew upstream versions like "7.1.2-19") keeps the base-release
+            # ranking, since it is a build of — not a pre-release of — the release.
+            return None
     return _Version(release, pre)
 
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,72 @@
+# Product Requirements Document — homebrew-safe-upgrade
+
+> Last updated: 2026-06-04 — living document.
+
+## Mission
+
+Security-first wrappers for `brew install` and `brew upgrade`. Every outdated package (and every incoming transitive dependency) is checked against 3 vulnerability databases against the **target version** before the install/upgrade proceeds. Clean packages move; vulnerable packages are blocked and listed separately. Operates as standalone CLI commands (`brew safe-install`, `brew safe-upgrade`, `brew safe-update`) — not as a Claude/Mistral hook.
+
+## Why it exists / problem
+
+`brew install` and `brew upgrade` perform no vulnerability check against the target version. [`brew-vulns`](https://github.com/Homebrew/homebrew-brew-vulns) audits the already-installed tree but doesn't gate incoming installs/upgrades. The result: a routine `brew upgrade` can move a user to a fresh-but-vulnerable formula version. This tool closes the install/upgrade gate by querying NIST NVD + OSV.dev + GitHub Advisory at the moment of action and blocking the bad ones while letting the clean ones through.
+
+## Scope (in)
+
+- `brew safe-install`, `brew safe-upgrade`, `brew safe-update` CLI commands.
+- **Multi-source vulnerability query:** NIST NVD + OSV.dev + GitHub Advisory (deduplicated, version-aware).
+- **Transitive dependency check (default on):**
+  - Deps that aren't installed at all → checked.
+  - Deps installed at an older version, being bumped → checked.
+  - Deps already at the target version → skipped (that's `brew-vulns`' job).
+  - Deduplicated across the upgrade batch (`openssl@3` in five outdated packages is checked once).
+- **Cask CPE map (curated)** for NVD keyword mapping where the formula slug ≠ CPE name.
+- **Auto-approve mode (`--yes`)** for CI / scripted use.
+- **SHA verification default-on** (per #33).
+- **Default `--min-age 3` for formulae** (per #32) — freshness hold; **CVE-aware bypass** when the installed version has a known CVE.
+- **macOS + Linux** (Homebrew on Linux supported; CI runs the test suite on Python 3.11 and 3.13).
+
+## Non-goals (out)
+
+- **Not a replacement for `brew-vulns`.** That tool audits the already-installed tree; this one gates incoming installs/upgrades. Complementary, not redundant.
+- **No post-install IoC scanning.** Out of scope here (lives in `composer-cve-gate`'s `safe-scan`; potential future cross-ecosystem tool).
+- **No Claude/Mistral hook surface.** Those live in `claude-code-cve-gate` / `mistral-code-cve-gate`. This repo is the standalone CLI.
+- **No SARIF / SBOM output.** Exit code is the contract.
+- **No telemetry / phone-home.**
+- **No API keys required.** Three databases are free + public; the tool stays free + zero-config.
+
+## Quality bar
+
+- **3-layer code review** on every PR (CodeRabbit + Mistral Vibe + source-verification).
+- **Signed releases** via maintainer YubiKey.
+- **No public security issues** — vulnerabilities are triaged privately and shipped as fixes.
+- **Python static-analysis floor:** Bandit + Mypy moderate strict (planned, separate PR).
+- **Test fixtures avoid live network/dates** wherever possible. (The `test_installed_old_version_is_treated_as_incoming` test previously read the live Homebrew openssl@3 release date and was flaky near openssl bumps; it now runs with `--min-age 0` so it makes no live date call.)
+- **Scanner lineage:** `dependency_security_check.py` shares lineage with the sibling cve-gate CLIs; correctness fixes are mirrored per repo by each repo's own runtime constraints.
+
+## Retirement / self-archive criteria
+
+Retired when Homebrew ships **either**:
+1. Native pre-install vulnerability gating that covers the same multi-source query + transitive dep scan + freshness hold, OR
+2. A formal plugin API that lets a community tool register as a true pre-install gate (rather than relying on the wrapper-CLI pattern).
+
+If neither happens but the broader ecosystem moves to a different package manager for AI-tooling use cases, evaluate then.
+
+## Architecture
+
+Bash entry points (`brew-safe-install`, `brew-safe-update`, `brew-safe-upgrade`) shell out to `dependency_security_check.py` (Python, stdlib-only) for the vulnerability check, plus a curated `cask_nvd_map.py` for NVD keyword/CPE resolution where the Homebrew token ≠ the CPE name.
+
+## References
+
+- **CLI counterparts:** [`composer-cve-gate`](https://github.com/sharkyger/composer-cve-gate), [`pip-cve-gate`](https://github.com/sharkyger/pip-cve-gate).
+- **Hook counterparts:** [`claude-code-cve-gate`](https://github.com/sharkyger/claude-code-cve-gate), [`mistral-code-cve-gate`](https://github.com/sharkyger/mistral-code-cve-gate).
+- **Adjacent:** [`brew-vulns`](https://github.com/Homebrew/homebrew-brew-vulns) — already-installed audit (complementary).
+
+## Status
+
+Current version: **v0.2.0** — **pre-stable** (per the pre-1.0 versioning rule). Recent shipped: SHA verification default-on, default `--min-age 3`, cask CPE map, arch-aware bottle-SHA fix, self-healing updater, and a pre-release-aware scanner comparator. Promotion to v1.0.0 gated on the quality floor (static-analysis + test stability).
+
+## Change log for this document
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-29 | skeleton | Initial draft from the README and project notes. |

--- a/tests/test_brew_safe_deps.py
+++ b/tests/test_brew_safe_deps.py
@@ -193,7 +193,13 @@ def test_already_installed_same_version_dep_is_skipped(mock_env):
 
 
 def test_installed_old_version_is_treated_as_incoming(mock_env, tmp_path):
-    """A dep installed at an older version than the latest must be checked."""
+    """A dep installed at an older version than the latest must be checked.
+
+    Uses --min-age 0 to disable the freshness hold: this test is about
+    incoming-version *detection*, not the age gate, and the default 3-day hold
+    would otherwise fetch openssl@3 3.5.0's real homebrew-core release date over
+    the network — making the test fail for ~3 days after every openssl@3 bump.
+    """
     write_formula_info(mock_env, "wget", "1.25.0")
     write_formula_info(mock_env, "openssl@3", "3.5.0")
     write_deps(mock_env, "wget", ["openssl@3"])
@@ -203,7 +209,7 @@ def test_installed_old_version_is_treated_as_incoming(mock_env, tmp_path):
     stub = make_cve_stub(tmp_path)  # all packages clean
 
     result = run_safe_install(
-        ["wget"],
+        ["wget", "--min-age", "0"],
         env_extra={"DEPENDENCY_SECURITY_CHECK": str(stub)},
         input_text="n\n",
     )

--- a/tests/test_version_validation.py
+++ b/tests/test_version_validation.py
@@ -153,3 +153,25 @@ def test_prerelease_below_fix_in_compound_range_is_affected():
     assert dsc.version_in_range("1.2.5rc1", ">= 1.0, < 1.2.5") is True
     # The final 1.2.5 is the fix → not affected.
     assert dsc.version_in_range("1.2.5", ">= 1.0, < 1.2.5") is False
+
+
+# ----------------------- unrecognized suffix: fail closed, don't coerce to final ----------
+
+
+def test_unrecognized_alpha_suffix_fails_closed_not_coerced_to_final():
+    # An unmodelled pre-release spelling must NOT sort as the final release (that
+    # would let "1.0-SNAPSHOT" bypass a "< 1.0" range). It fails closed instead.
+    assert dsc.parse_version("1.0-SNAPSHOT") is None
+    assert dsc.parse_version("1.0foo") is None
+    assert dsc.parse_version("1.0.post1") is None
+    assert dsc.parse_version("1.0.") is None
+    # The bypass is closed: 1.0-SNAPSHOT is treated as affected by "< 1.0".
+    assert dsc.version_in_range("1.0-SNAPSHOT", "< 1.0") is True
+
+
+def test_homebrew_numeric_patch_suffix_keeps_base_release():
+    # Real Homebrew/upstream versions like imagemagick "7.1.2-19" are a build of
+    # the release, not a pre-release — keep the base ranking (must NOT fail closed).
+    assert dsc.parse_version("7.1.2-19") == dsc.parse_version("7.1.2")
+    assert dsc.version_in_range("7.1.2-19", "< 7.1.3") is True  # below the fix
+    assert dsc.version_in_range("7.1.2-19", "< 7.1.2") is False  # at/above the base

--- a/tests/test_version_validation.py
+++ b/tests/test_version_validation.py
@@ -1,0 +1,155 @@
+"""Version-comparison regression tests (HIGH-severity scanner bypass).
+
+Guards two bugs in dependency_security_check.py:
+
+1. PEP 440 pre-release drop. The old tuple-based parse_version silently lost
+   pre-release suffixes — parse_version('1.0-beta') == parse_version('1.0') —
+   so a vulnerable pre-release sorted equal to its release and was judged
+   "not affected" against a "fixed in X" range → install/upgrade allowed.
+   (Same class caught in composer-cve-gate as Mistral Vibe HIGH #1.)
+
+2. The '=' operator precedence bug. In version_in_range, `or op == "="` was
+   unparenthesized, so Python's `and`-binds-tighter-than-`or` made a bare `=N`
+   constraint ALWAYS return "not affected" — a vulnerable package pinned with
+   `= X` slipped through.
+
+Both are fixed by parsing with a small stdlib pre-release-aware comparator and
+parenthesizing the operator block as ((op == "=" or op == "==") and v != ref).
+"""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO))
+
+import dependency_security_check as dsc  # noqa: E402
+
+# ----------------------- parse_version: PEP 440 -----------------------
+
+
+def test_prerelease_sorts_below_its_release():
+    assert dsc.parse_version("1.0-beta") < dsc.parse_version("1.0")
+    assert dsc.parse_version("1.0.0-beta") < dsc.parse_version("1.0.0")
+    assert dsc.parse_version("1.0-rc.1") < dsc.parse_version("1.0")
+    assert dsc.parse_version("2.0.0a1") < dsc.parse_version("2.0.0")
+
+
+def test_parse_version_strips_v_and_equals_prefixes():
+    assert dsc.parse_version("v1.2.3") == dsc.parse_version("1.2.3")
+    assert dsc.parse_version("=1.2.3") == dsc.parse_version("1.2.3")
+
+
+def test_parse_version_invalid_returns_none():
+    assert dsc.parse_version("") is None
+    assert dsc.parse_version(None) is None
+    assert dsc.parse_version("not-a-version") is None
+
+
+# ----------------------- the pre-release bypass (HIGH #1) -----------------------
+
+
+def test_vulnerable_prerelease_below_fix_is_still_affected():
+    # "fixed in 1.0": a 1.0-beta pre-release is BELOW 1.0, so still vulnerable.
+    assert dsc.version_in_range("1.0-beta", "< 1.0") is True
+    assert dsc.version_in_range("1.0.0-rc.1", "< 1.0.0") is True
+
+
+def test_release_at_or_above_fix_is_not_affected():
+    assert dsc.version_in_range("1.0", "< 1.0") is False
+    assert dsc.version_in_range("1.1", "< 1.0") is False
+
+
+# ----------------------- the '=' operator bug (HIGH #2) -----------------------
+
+
+def test_equals_operator_affects_only_the_exact_version():
+    assert dsc.version_in_range("1.2.3", "= 1.2.3") is True
+    assert dsc.version_in_range("1.2.4", "= 1.2.3") is False
+    assert dsc.version_in_range("1.2.2", "= 1.2.3") is False
+
+
+def test_double_equals_operator():
+    assert dsc.version_in_range("1.2.3", "== 1.2.3") is True
+    assert dsc.version_in_range("1.2.4", "== 1.2.3") is False
+
+
+def test_not_equals_operator():
+    assert dsc.version_in_range("1.2.3", "!= 1.2.3") is False
+    assert dsc.version_in_range("1.2.4", "!= 1.2.3") is True
+
+
+# ----------------------- ranges + fail-closed -----------------------
+
+
+def test_compound_range_boundaries():
+    assert dsc.version_in_range("1.5", ">= 1.0, < 2.0") is True
+    assert dsc.version_in_range("2.5", ">= 1.0, < 2.0") is False
+    assert dsc.version_in_range("0.5", ">= 1.0, < 2.0") is False
+
+
+def test_empty_inputs_fail_closed_affected():
+    assert dsc.version_in_range("", "< 1.0") is True
+    assert dsc.version_in_range("1.0", "") is True
+
+
+def test_unparseable_constraint_fails_closed_affected():
+    # A constraint the scanner can't disprove must not mark the package clean.
+    assert dsc.version_in_range("1.2.3", "< not-a-version") is True
+
+
+# ----------------------- explicit pre-release ordering -----------------------
+
+
+def test_prerelease_marker_ordering_dev_alpha_beta_rc_final():
+    order = ["1.0.dev1", "1.0a1", "1.0b1", "1.0rc1", "1.0"]
+    parsed = [dsc.parse_version(s) for s in order]
+    for lo, hi in zip(parsed, parsed[1:], strict=False):
+        assert lo < hi, f"{order}: {lo} should sort below {hi}"
+
+
+def test_prerelease_number_ordering():
+    assert dsc.parse_version("1.0rc1") < dsc.parse_version("1.0rc2")
+    assert dsc.parse_version("1.0a2") < dsc.parse_version("1.0b1")
+
+
+def test_prerelease_spelling_equivalence():
+    assert dsc.parse_version("1.0alpha1") == dsc.parse_version("1.0a1")
+    assert dsc.parse_version("1.0beta2") == dsc.parse_version("1.0b2")
+    assert dsc.parse_version("1.0c1") == dsc.parse_version("1.0rc1")
+
+
+def test_trailing_zero_equivalence():
+    assert dsc.parse_version("1.0") == dsc.parse_version("1.0.0")
+    assert dsc.parse_version("1") == dsc.parse_version("1.0.0")
+    assert dsc.parse_version("1.2") < dsc.parse_version("1.2.1")
+
+
+def test_homebrew_revision_and_build_metadata_ignored_for_order():
+    assert dsc.parse_version("3.5.0_1") == dsc.parse_version("3.5.0")
+    assert dsc.parse_version("1.2.3+build9") == dsc.parse_version("1.2.3")
+
+
+# ----------------------- more '=' / range edge cases -----------------------
+
+
+def test_equals_with_prerelease_target():
+    assert dsc.version_in_range("1.0rc1", "= 1.0rc1") is True
+    assert dsc.version_in_range("1.0", "= 1.0rc1") is False
+
+
+def test_hyphenated_prerelease_constraint_is_captured():
+    # The constraint regex must not truncate a hyphenated pre-release ref to its
+    # numeric part — "= 1.0-beta" must match exactly 1.0-beta, not 1.0.
+    assert dsc.version_in_range("1.0-beta", "= 1.0-beta") is True
+    assert dsc.version_in_range("1.0", "= 1.0-beta") is False
+    assert dsc.version_in_range("1.0-alpha", "= 1.0-beta") is False
+    # "< 1.0-beta": a 1.0-alpha pre-release is below the beta → affected.
+    assert dsc.version_in_range("1.0-alpha", "< 1.0-beta") is True
+
+
+def test_prerelease_below_fix_in_compound_range_is_affected():
+    # A 1.2.5 pre-release is below the "fixed in 1.2.5" boundary → still affected.
+    assert dsc.version_in_range("1.2.5rc1", ">= 1.0, < 1.2.5") is True
+    # The final 1.2.5 is the fix → not affected.
+    assert dsc.version_in_range("1.2.5", ">= 1.0, < 1.2.5") is False


### PR DESCRIPTION
## Pre-release-aware version comparison (fixes a HIGH scanner bypass)

The CVE range matcher decided "affected vs not-affected" with a tuple-based `parse_version` that **silently dropped pre-release suffixes**: `1.0-beta` → `(1, 0)`, equal to `1.0`. So a vulnerable pre-release sorted *equal to* its release and was judged **not affected** against a "fixed in X" advisory range — letting an install/upgrade proceed on a vulnerable package.

A second, independent bug: a bare `= X` constraint always read "not affected" — an unparenthesized `or op == "="` that, with Python's `and`-binds-tighter-than-`or`, ignored the version entirely.

## Fix

- **Small stdlib pre-release-aware comparator** (`_Version` + `parse_version`): `dev < alpha < beta < rc < final`, trailing-zero equivalence (`1.0 == 1.0.0`), Homebrew revisions/build-metadata ignored for order. **No `packaging` runtime dependency** — the dogfood proved Homebrew's `python@3.12` is externally-managed and lacks top-level `packaging`, so depending on it would fail-close the whole tool for tap/script installs. The tool stays stdlib-only.
- **Operator block parenthesized**: `((op == "=" or op == "==") and v != ref)`.
- **Constraint regex** now captures hyphenated pre-release refs (`= 1.0-beta` no longer truncates to `1.0`).
- Every comparison site is **None-safe** (fail-closed `_ver_lt/le/gt/ge` helpers); unparseable versions/constraints are treated as **affected**.

## Tests / validation

`tests/test_version_validation.py` — 19 cases: explicit pre-release ordering (`alpha<beta<rc<final`), spelling equivalence, trailing-zero, `=`/`==`/`!=` edge cases (incl. hyphenated), compound ranges, and fail-closed-on-unparseable. **117 tests pass**, ruff + shellcheck clean. **Stdlib-only dogfood** (x86_64 linuxbrew, `packaging` absent): scanner flags `requests 2.19.0` (exit 1), pre-release ordering + `=` fix verified, no packaging error.

Also in this PR (per the handoff): the flaky `test_installed_old_version_is_treated_as_incoming` now runs with `--min-age 0` (no live openssl@3 release-date fetch), and the parked `docs/PRD.md` ships (internal references stripped for public).

Bandit + Mypy static-analysis floor is a **separate** PR (not bundled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Homebrew tap installation method for safe-upgrade.

* **Bug Fixes**
  * Corrected pre-release-aware version comparison in vulnerability detection with fail-closed behavior for unparseable inputs.
  * Fixed intermittent openssl@3 timing test by making it deterministic.

* **Tests**
  * Added comprehensive version parsing/comparison regression tests; clarified existing test to disable age gating.

* **Documentation**
  * Added Product Requirements Document and updated CHANGELOG with security and install guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->