### PR TITLE
docs: add a dedicated Updating section

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,16 @@ Why `--self`: a plain `brew upgrade safe-upgrade` pulls safe-upgrade's own depen
 
 > This updates **the tool itself**. To CVE-gate an upgrade of *all* your outdated packages, that's the everyday `brew safe-upgrade` (no `--self`).
 
+**Full update routine** — bring both the tool and everything else current, in order:
+
+```bash
+brew update        # refresh Homebrew's metadata
+brew safe-update   # update safe-upgrade itself (gated — runs --self on a formula install)
+brew safe-upgrade  # then CVE-gate an upgrade of everything else outdated
+```
+
+Update the updater first, then everything else — the same *refresh, then upgrade* rhythm you already know from `apt update && apt upgrade` (or `dnf upgrade`, `pacman -Syu`, …). The leading `brew update` is optional — `safe-update` and `safe-upgrade` each run it internally.
+
 ## brew safe-install
 
 Same security gate, but for installing new packages.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Keep **safe-upgrade itself** current through the gated path — pick the line fo
 | Install route | Update with |
 | ------------- | ----------- |
 | **Homebrew formula** (`brew install sharkyger/tap/safe-upgrade`) | `brew safe-upgrade --self` — gates safe-upgrade's own dependencies first (fail-closed), then upgrades the formula. `brew safe-update` runs this for you. |
-| **Script / curl** (`install.sh`) | `brew safe-update` — re-fetches the tools from the latest release, verifies every file against the signed `SHA256SUMS`, and swaps them in atomically (fail-closed). |
+| **Script / curl** (`install.sh`) | `brew safe-update` — re-fetches the tools from the latest release, verifies every file against the `SHA256SUMS` checksum manifest, and swaps them in atomically (fail-closed). |
 
 Why `--self`: a plain `brew upgrade safe-upgrade` pulls safe-upgrade's own dependencies (its managed Python and that Python's dependencies — `openssl@3`, `sqlite`, …) through Homebrew **ungated** — the gap ([#87](https://github.com/sharkyger/homebrew-safe-upgrade/issues/87)) that `--self` closes.
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,19 @@ brew safe-upgrade --no-verify-sha
 
 Casks are out of scope — brew already enforces the cask-file SHA on every install, so duplicating that check here adds no signal.
 
+## Updating
+
+Keep **safe-upgrade itself** current through the gated path — pick the line for your install route (`brew safe-upgrade --version` tells you which you're on):
+
+| Install route | Update with |
+| ------------- | ----------- |
+| **Homebrew formula** (`brew install sharkyger/tap/safe-upgrade`) | `brew safe-upgrade --self` — gates safe-upgrade's own dependencies first (fail-closed), then upgrades the formula. `brew safe-update` runs this for you. |
+| **Script / curl** (`install.sh`) | `brew safe-update` — re-fetches the tools from the latest release, verifies every file against the signed `SHA256SUMS`, and swaps them in atomically (fail-closed). |
+
+Why `--self`: a plain `brew upgrade safe-upgrade` pulls safe-upgrade's own dependencies (its managed Python and that Python's dependencies — `openssl@3`, `sqlite`, …) through Homebrew **ungated** — the gap ([#87](https://github.com/sharkyger/homebrew-safe-upgrade/issues/87)) that `--self` closes.
+
+> This updates **the tool itself**. To CVE-gate an upgrade of *all* your outdated packages, that's the everyday `brew safe-upgrade` (no `--self`).
+
 ## brew safe-install
 
 Same security gate, but for installing new packages.


### PR DESCRIPTION
Consolidates the update instructions into one discoverable `## Updating` section (near the top, after *How it works*) instead of leaving them split between the `brew safe-update` section and the tap-install subsection.

Covers both routes at a glance:
- **Homebrew formula** → `brew safe-upgrade --self` (`brew safe-update` runs it for you)
- **Script / curl** → `brew safe-update`

Plus the *why* (`--self` closes the #87 ungated-dep gap) and the distinction that this updates the tool itself vs `brew safe-upgrade` gating all outdated packages. Docs-only; markdownlint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Updating” section to explain how to keep Safe Upgrade current.
  * Clarified the update steps for Homebrew and script/curl installs.
  * Noted that the gated update flow helps avoid unsafe upgrades of managed components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->